### PR TITLE
fix: [TS-5] The swiping is a bit weird in the summary page

### DIFF
--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -19,7 +19,7 @@ const SettingsPageContent: React.FC = () => {
     };
 
     return (
-        <div className="bg-background p-4 min-h-screen flex flex-col gap-4">
+        <div className="bg-background p-4 flex flex-col gap-4">
             <div className="w-full mx-auto p-6 bg-surface rounded-lg shadow-md border border-border">
                 <h2 className="text-2xl font-bold mb-6 text-text-main">
                     App Appearance

--- a/app/summary/page.tsx
+++ b/app/summary/page.tsx
@@ -7,7 +7,7 @@ import { useExpenses } from "../../src/stores/ExpensesStore";
 import { useConfig } from "../../src/stores/ConfigStore";
 import { useAuthState } from "../../src/stores/AuthStore";
 
-const ListPage: React.FC = () => {
+const SummaryPage: React.FC = () => {
     const { expenses, apiState, refreshExpenses } = useExpenses();
     const { user } = useAuthState();
     const { sheetConfig } = useConfig();
@@ -189,4 +189,4 @@ const ListPage: React.FC = () => {
     );
 };
 
-export default ListPage;
+export default SummaryPage;

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -22,7 +22,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
     }
 
     return (
-        <div className="min-h-screen bg-background text-text-main font-sans transition-colors duration-300">
+        <div className="min-h-dvh bg-background text-text-main font-sans transition-colors duration-300">
             <Layout>
                 {children}
             </Layout>

--- a/components/LoginView.tsx
+++ b/components/LoginView.tsx
@@ -5,7 +5,7 @@ import { SignInManager } from "./SignInManager";
 
 export function LoginView() {
     return (
-        <div className="min-h-screen flex items-center justify-center bg-background px-4 transition-colors">
+        <div className="min-h-dvh flex items-center justify-center bg-background px-4 transition-colors">
             <div className="max-w-md w-full bg-surface rounded-xl shadow-lg p-8 animate-in fade-in zoom-in duration-300 border border-border">
                 <h1 className="text-3xl font-bold text-center text-primary mb-2">
                     TripSplit


### PR DESCRIPTION
looks like the `min-h-screen` apply the `100vh` and extend the page content length out of the screen.
Change to use `100dvh` instead

https://happy9990929.github.io/2024/07/17/css-height-unit/

including commits:
- https://github.com/JosephT5566/TravelSplit/commit/38855fcc9efdfb3e6ae9c9e918ea953904cf226f