### PR TITLE
feat: [TS-3] When we click the Add expense button, the date should be the selected data directly

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -19,6 +19,7 @@ const MainPage: React.FC = () => {
     const { user } = useAuth();
     const [expense, setExpense] = useState<Expense | null>(null);
     const [isDialogOpen, setIsDialogOpen] = useState<boolean>(false);
+    const [currentDate, setCurrentDate] = useState(new Date());
 
     const dialogRef = useRef<HTMLDialogElement>(null);
 
@@ -69,6 +70,7 @@ const MainPage: React.FC = () => {
                 onOpenExpenseForm={openExpenseForm}
                 onRefresh={refreshExpenses}
                 isRefreshing={apiState.isFetching}
+                onCurrentDateChange={setCurrentDate}
             />
 
             {user && (
@@ -77,6 +79,7 @@ const MainPage: React.FC = () => {
                         <ExpenseForm
                             onCancel={closeExpenseForm}
                             isDialogOpen={isDialogOpen}
+                            selectedDate={currentDate}
                         />
                     ) : (
                         <ExpenseDetail expense={expense} onCancel={closeExpenseForm} />

--- a/components/ExpenseForm.tsx
+++ b/components/ExpenseForm.tsx
@@ -21,6 +21,7 @@ import { useAddExpense } from "../services/dataFetcher";
 interface Props {
     onCancel: () => void;
     isDialogOpen: boolean;
+    selectedDate: Date;
 }
 
 const InputGroup = ({
@@ -48,7 +49,7 @@ const InputGroup = ({
     </div>
 );
 
-export const ExpenseForm: React.FC<Props> = ({ onCancel, isDialogOpen }) => {
+export const ExpenseForm: React.FC<Props> = ({ onCancel, isDialogOpen, selectedDate }) => {
     const { user } = useAuth();
     const currentUser = user;
     if (!currentUser) {
@@ -61,7 +62,7 @@ export const ExpenseForm: React.FC<Props> = ({ onCancel, isDialogOpen }) => {
     }
     const { categories, currencies, users } = config;
 
-    const [date, setDate] = useState(format(new Date(), "yyyy-MM-dd"));
+    const [date, setDate] = useState(format(selectedDate, "yyyy-MM-dd"));
     const [currency, setCurrency] = useState("TWD");
     const [exchangeRate, setExchangeRate] = useState<number>(
         currencies[currency]
@@ -92,22 +93,23 @@ export const ExpenseForm: React.FC<Props> = ({ onCancel, isDialogOpen }) => {
 
     useEffect(() => {
         if (isDialogOpen) {
-            return;
+            // When dialog opens, set the date to the selected date from the list
+            setDate(format(selectedDate, "yyyy-MM-dd"));
+        } else {
+            // Reset all state values to their initial values when dialog closes
+            setDate(format(new Date(), "yyyy-MM-dd"));
+            setCurrency("TWD");
+            setExchangeRate(currencies["TWD"]);
+            setCategory("");
+            setPayer(currentUser.email);
+            setItemName("");
+            setAmount("");
+            setPayType("myself");
+            setSelectedUsers([]);
+            setSplitMode("equally");
+            setSpecificSplits({});
         }
-
-        // Reset all state values to their initial values
-        setDate(format(new Date(), "yyyy-MM-dd"));
-        setCurrency("TWD");
-        setExchangeRate(currencies["TWD"]);
-        setCategory("");
-        setPayer(currentUser.email);
-        setItemName("");
-        setAmount("");
-        setPayType("myself");
-        setSelectedUsers([]);
-        setSplitMode("equally");
-        setSpecificSplits({});
-    }, [isDialogOpen, currencies, currentUser.email]);
+    }, [isDialogOpen, selectedDate, currencies, currentUser.email]);
 
     useEffect(() => {
         const total = Object.values(specificSplits).reduce(

--- a/components/ExpenseList.tsx
+++ b/components/ExpenseList.tsx
@@ -20,6 +20,7 @@ interface Props {
     onOpenExpenseForm: (expense?: Expense) => void;
     onRefresh: () => void;
     isRefreshing: boolean;
+    onCurrentDateChange: (date: Date) => void;
 }
 
 export const ExpenseList: React.FC<Props> = ({
@@ -27,6 +28,7 @@ export const ExpenseList: React.FC<Props> = ({
     onOpenExpenseForm,
     onRefresh,
     isRefreshing,
+    onCurrentDateChange,
 }) => {
     const { user } = useAuthState();
     const { sheetConfig } = useConfig();
@@ -55,6 +57,10 @@ export const ExpenseList: React.FC<Props> = ({
     const currentEmblaDate = useMemo(() => {
         return allDates[selectedIndex] || new Date();
     }, [allDates, selectedIndex]);
+
+    useEffect(() => {
+        onCurrentDateChange(currentEmblaDate);
+    }, [currentEmblaDate, onCurrentDateChange]);
 
     const goToDate = useCallback(
         (date: Date) => {


### PR DESCRIPTION
Let's set the state `currentDate` in the parent page. Then pass the state and update method to the `ExpenseList` and `ExpenseForm`. So that the related value can be synced. 