### PR TITLE
Feat: Support multi sheet ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,11 @@ The application interacts with two main services:
     NEXT_PUBLIC_TRAVEL_SPLIT_GCF=https://your-gcf-url.cloudfunctions.net
     NEXT_PUBLIC_SHEET_ID=your_google_sheet_id
     ```
+    To offer multiple sheets, set `NEXT_PUBLIC_SHEET_ID` to a JSON array:
+
+    ```env
+    NEXT_PUBLIC_SHEET_ID=<`sheet_id_1`>,<`sheet_id_2`>
+    ```
     For local development, you will typically point `NEXT_PUBLIC_AUTH_PROXY` and `NEXT_PUBLIC_TRAVEL_SPLIT_GCF` to their respective local URLs.
 
 3. **Run the app:**

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ The application interacts with two main services:
     To offer multiple sheets, set `NEXT_PUBLIC_SHEET_ID` to a JSON array:
 
     ```env
-    NEXT_PUBLIC_SHEET_ID=<`sheet_id_1`>,<`sheet_id_2`>
+    NEXT_PUBLIC_SHEET_ID=<sheet_id_1>,<sheet_id_2> or ["sheet_id_1","sheet_id_2"]
     ```
     For local development, you will typically point `NEXT_PUBLIC_AUTH_PROXY` and `NEXT_PUBLIC_TRAVEL_SPLIT_GCF` to their respective local URLs.
 

--- a/app/select-sheet/page.tsx
+++ b/app/select-sheet/page.tsx
@@ -22,8 +22,8 @@ const formatSheetId = (sheetId: string) => {
 };
 
 const getSheetTitle = (sheetConfig: SheetConfig | undefined, index: number) => {
-    if (sheetConfig?.title) {
-        return sheetConfig.title;
+    if (sheetConfig?.tripName) {
+        return sheetConfig.tripName;
     }
 
     if (sheetConfig?.startDate || sheetConfig?.endDate) {

--- a/app/select-sheet/page.tsx
+++ b/app/select-sheet/page.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import React from "react";
+import { useQueries, useQueryClient } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+import { AlertTriangle, CheckCircle2, RefreshCw, Table2 } from "lucide-react";
+import { api } from "@/services/api";
+import { EXPENSES_KEY, SHEET_CONFIG_KEY } from "@/services/cacheKeys";
+import { SheetConfig } from "@/src/types";
+import {
+    getActiveSheetIdOrNull,
+    getAvailableSheetIds,
+    saveSelectedSheetId,
+} from "@/src/utils/sheetSelection";
+
+const formatSheetId = (sheetId: string) => {
+    if (sheetId.length <= 12) {
+        return sheetId;
+    }
+
+    return `${sheetId.slice(0, 6)}...${sheetId.slice(-6)}`;
+};
+
+const getSheetTitle = (sheetConfig: SheetConfig | undefined, index: number) => {
+    if (sheetConfig?.title) {
+        return sheetConfig.title;
+    }
+
+    if (sheetConfig?.startDate || sheetConfig?.endDate) {
+        return [sheetConfig.startDate, sheetConfig.endDate]
+            .filter(Boolean)
+            .join(" - ");
+    }
+
+    return `Google Sheet ${index + 1}`;
+};
+
+export default function SelectSheetPage() {
+    const router = useRouter();
+    const queryClient = useQueryClient();
+    const sheetIds = getAvailableSheetIds();
+    const selectedSheetId = getActiveSheetIdOrNull();
+
+    const sheetQueries = useQueries({
+        queries: sheetIds.map((sheetId) => ({
+            queryKey: [SHEET_CONFIG_KEY, sheetId],
+            queryFn: () => api.getSheetConfig(sheetId),
+            enabled: sheetIds.length > 1,
+        })),
+    });
+
+    const handleSelectSheet = (sheetId: string) => {
+        saveSelectedSheetId(sheetId);
+        queryClient.removeQueries({ queryKey: [SHEET_CONFIG_KEY] });
+        queryClient.removeQueries({ queryKey: [EXPENSES_KEY] });
+        router.replace("/");
+    };
+
+    return (
+        <main className="min-h-dvh bg-background px-4 py-8 text-text-main">
+            <div className="mx-auto flex min-h-[calc(100dvh-4rem)] w-full max-w-2xl flex-col justify-center gap-6">
+                <div className="space-y-2">
+                    <h1 className="text-3xl font-bold text-primary">
+                        Select Trip Sheet
+                    </h1>
+                    <p className="text-sm text-text-muted">
+                        Available Google Sheets
+                    </p>
+                </div>
+
+                <div className="grid grid-cols-1 gap-3">
+                    {sheetIds.map((sheetId, index) => {
+                        const query = sheetQueries[index];
+                        const sheetConfig = query?.data;
+                        const isSelected = selectedSheetId === sheetId;
+
+                        return (
+                            <button
+                                key={sheetId}
+                                type="button"
+                                onClick={() => handleSelectSheet(sheetId)}
+                                className={`rounded-lg border bg-surface p-4 text-left shadow-sm transition hover:border-primary hover:shadow-md active:scale-[0.99] ${
+                                    isSelected
+                                        ? "border-primary ring-2 ring-primary/20"
+                                        : "border-border"
+                                }`}
+                            >
+                                <div className="flex items-start gap-3">
+                                    <div className="rounded-md bg-primary/10 p-2 text-primary">
+                                        <Table2 size={22} />
+                                    </div>
+                                    <div className="min-w-0 flex-1">
+                                        <div className="flex items-center justify-between gap-3">
+                                            <h2 className="truncate text-lg font-semibold">
+                                                {query?.isLoading
+                                                    ? "Loading sheet..."
+                                                    : getSheetTitle(
+                                                          sheetConfig,
+                                                          index,
+                                                      )}
+                                            </h2>
+                                            {isSelected && (
+                                                <CheckCircle2
+                                                    size={20}
+                                                    className="shrink-0 text-primary"
+                                                />
+                                            )}
+                                        </div>
+                                        <p className="mt-1 font-mono text-xs text-text-muted">
+                                            {formatSheetId(sheetId)}
+                                        </p>
+                                        {query?.isError && (
+                                            <div className="mt-3 flex items-center gap-2 text-sm text-red-600">
+                                                <AlertTriangle size={16} />
+                                                Unable to load sheet setting.
+                                            </div>
+                                        )}
+                                        {query?.isFetching && !query.isLoading && (
+                                            <div className="mt-3 flex items-center gap-2 text-sm text-text-muted">
+                                                <RefreshCw
+                                                    size={16}
+                                                    className="animate-spin"
+                                                />
+                                                Refreshing setting
+                                            </div>
+                                        )}
+                                    </div>
+                                </div>
+                            </button>
+                        );
+                    })}
+                </div>
+
+                {sheetIds.length === 0 && (
+                    <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+                        Missing NEXT_PUBLIC_SHEET_ID env variable.
+                    </div>
+                )}
+            </div>
+        </main>
+    );
+}

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -1,12 +1,51 @@
 "use client";
 
 import React from "react";
+import { usePathname, useRouter } from "next/navigation";
 import { Layout } from "./Layout";
 import { LoginView } from "./LoginView";
 import { useAuthState } from "../src/stores/AuthStore";
+import {
+    getAvailableSheetIds,
+    getStoredSheetId,
+    saveSelectedSheetId,
+} from "@/src/utils/sheetSelection";
 
 export function AppShell({ children }: { children: React.ReactNode }) {
     const { isAuthInitialized, isSignedIn } = useAuthState();
+    const pathname = usePathname();
+    const router = useRouter();
+    const [isSheetSelectionReady, setIsSheetSelectionReady] =
+        React.useState(false);
+
+    React.useEffect(() => {
+        if (!isAuthInitialized || !isSignedIn) {
+            return;
+        }
+
+        const availableSheetIds = getAvailableSheetIds();
+        if (availableSheetIds.length <= 1) {
+            if (availableSheetIds[0]) {
+                saveSelectedSheetId(availableSheetIds[0]);
+            }
+            setIsSheetSelectionReady(true);
+            if (pathname === "/select-sheet") {
+                router.replace("/");
+            }
+            return;
+        }
+
+        const selectedSheetId = getStoredSheetId();
+        if (!selectedSheetId) {
+            setIsSheetSelectionReady(pathname === "/select-sheet");
+            if (pathname !== "/select-sheet") {
+                router.replace("/select-sheet");
+            }
+            return;
+        }
+
+        setIsSheetSelectionReady(true);
+    }, [isAuthInitialized, isSignedIn, pathname, router]);
 
     if (!isAuthInitialized) {
         return (
@@ -21,12 +60,21 @@ export function AppShell({ children }: { children: React.ReactNode }) {
         return <LoginView />;
     }
 
+    if (!isSheetSelectionReady) {
+        return (
+            <div className="flex h-screen w-screen items-center justify-center bg-background">
+                <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary"></div>
+            </div>
+        );
+    }
+
     return (
         <div className="min-h-dvh bg-background text-text-main font-sans transition-colors duration-300">
-            <Layout>
-                {children}
-            </Layout>
+            {pathname === "/select-sheet" ? (
+                children
+            ) : (
+                <Layout>{children}</Layout>
+            )}
         </div>
     );
 }
-

--- a/components/SideDrawer.tsx
+++ b/components/SideDrawer.tsx
@@ -2,7 +2,7 @@
 
 import React from "react";
 import { FocusTrap } from "focus-trap-react";
-import { LogOut, FileCog, X, RefreshCw } from "lucide-react";
+import { LogOut, FileCog, X, RefreshCw, ArrowLeftRight } from "lucide-react";
 import Link from "next/link";
 import { useAuthActions, useAuthState } from "../src/stores/AuthStore";
 import { AppConfig } from "../src/types";
@@ -86,6 +86,17 @@ export const SideDrawer: React.FC = () => {
                             </div>
                         </div>
 
+                        {isSheetSelectionRequired() && (
+                            <Link
+                                href="/select-sheet"
+                                onClick={closeDrawer}
+                                className="mb-3 flex w-full items-center gap-3 rounded-lg border border-primary/30 bg-primary/10 px-4 py-3 text-sm font-semibold text-primary transition hover:border-primary hover:bg-primary/15 active:scale-[0.99]"
+                            >
+                                <ArrowLeftRight size={18} />
+                                Switch Sheet
+                            </Link>
+                        )}
+
                         <div className="collapse collapse-arrow bg-base-200/50 border border-base-300 rounded-xl">
                             <input type="checkbox" name="my-accordion-2" />
                             <div className="collapse-title flex items-center gap-3 text-sm font-bold">
@@ -94,34 +105,23 @@ export const SideDrawer: React.FC = () => {
                                 Sheet 設定
                             </div>
                             <div className="collapse-content ">
-                                <div className="flex items-center gap-2">
-                                    <button
-                                        className="p-1 text-primary bg-surface border border-border rounded-full"
-                                        onClick={(e) => {
-                                            e.stopPropagation();
-                                            refetchSheetConfig();
-                                        }}
-                                        disabled={isFetchingConfig}
-                                    >
-                                        <RefreshCw
-                                            size={12}
-                                            className={
-                                                isFetchingConfig
-                                                    ? "animate-spin"
-                                                    : ""
-                                            }
-                                        />
-                                    </button>
-                                    {isSheetSelectionRequired() && (
-                                        <Link
-                                            href="/select-sheet"
-                                            onClick={closeDrawer}
-                                            className="btn btn-xs btn-outline"
-                                        >
-                                            Switch Sheet
-                                        </Link>
-                                    )}
-                                </div>
+                                <button
+                                    className="p-1 text-primary bg-surface border border-border rounded-full"
+                                    onClick={(e) => {
+                                        e.stopPropagation();
+                                        refetchSheetConfig();
+                                    }}
+                                    disabled={isFetchingConfig}
+                                >
+                                    <RefreshCw
+                                        size={12}
+                                        className={
+                                            isFetchingConfig
+                                                ? "animate-spin"
+                                                : ""
+                                        }
+                                    />
+                                </button>
                                 {sheetConfig ? (
                                     <div className="space-y-4 pt-2">
                                         {/* Date Section */}

--- a/components/SideDrawer.tsx
+++ b/components/SideDrawer.tsx
@@ -3,11 +3,13 @@
 import React from "react";
 import { FocusTrap } from "focus-trap-react";
 import { LogOut, FileCog, X, RefreshCw } from "lucide-react";
+import Link from "next/link";
 import { useAuthActions, useAuthState } from "../src/stores/AuthStore";
 import { AppConfig } from "../src/types";
 import { useUI } from "../src/stores/UIStore";
 import { useConfig } from "../src/stores/ConfigStore";
 import { format } from "date-fns";
+import { isSheetSelectionRequired } from "@/src/utils/sheetSelection";
 
 export const SideDrawer: React.FC = () => {
     const { signOut } = useAuthActions();
@@ -92,23 +94,34 @@ export const SideDrawer: React.FC = () => {
                                 Sheet 設定
                             </div>
                             <div className="collapse-content ">
-                                <button
-                                    className="p-1 text-primary bg-surface border border-border rounded-full"
-                                    onClick={(e) => {
-                                        e.stopPropagation();
-                                        refetchSheetConfig();
-                                    }}
-                                    disabled={isFetchingConfig}
-                                >
-                                    <RefreshCw
-                                        size={12}
-                                        className={
-                                            isFetchingConfig
-                                                ? "animate-spin"
-                                                : ""
-                                        }
-                                    />
-                                </button>
+                                <div className="flex items-center gap-2">
+                                    <button
+                                        className="p-1 text-primary bg-surface border border-border rounded-full"
+                                        onClick={(e) => {
+                                            e.stopPropagation();
+                                            refetchSheetConfig();
+                                        }}
+                                        disabled={isFetchingConfig}
+                                    >
+                                        <RefreshCw
+                                            size={12}
+                                            className={
+                                                isFetchingConfig
+                                                    ? "animate-spin"
+                                                    : ""
+                                            }
+                                        />
+                                    </button>
+                                    {isSheetSelectionRequired() && (
+                                        <Link
+                                            href="/select-sheet"
+                                            onClick={closeDrawer}
+                                            className="btn btn-xs btn-outline"
+                                        >
+                                            Switch Sheet
+                                        </Link>
+                                    )}
+                                </div>
                                 {sheetConfig ? (
                                     <div className="space-y-4 pt-2">
                                         {/* Date Section */}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/services/api.ts
+++ b/services/api.ts
@@ -8,6 +8,7 @@ import {
     DeleteExpenseResponse,
 } from "../src/types";
 import logger from "@/src/utils/logger";
+import { getSelectedSheetId } from "@/src/utils/sheetSelection";
 
 let isRefreshing = false;
 let failedQueue: {
@@ -145,12 +146,11 @@ async function processUserResponse(response: Response): Promise<User> {
     return response.json();
 }
 
-const getGcfUrl = (path: string) => {
+const getGcfUrl = (path: string, sheetId = getSelectedSheetId()) => {
     const gcfUrl = process.env.NEXT_PUBLIC_TRAVEL_SPLIT_GCF;
     if (!gcfUrl) {
         throw new Error("Missing NEXT_PUBLIC_TRAVEL_SPLIT_GCF env variable.");
     }
-    const sheetId = process.env.NEXT_PUBLIC_SHEET_ID;
     if (!sheetId) {
         throw new Error("Missing NEXT_PUBLIC_SHEET_ID env variable.");
     }
@@ -217,8 +217,8 @@ export function mapRawExpenseToExpense(
 }
 
 export const api = {
-    async getSheetConfig(): Promise<SheetConfig> {
-        const url = getGcfUrl("/setting");
+    async getSheetConfig(sheetId?: string): Promise<SheetConfig> {
+        const url = getGcfUrl("/setting", sheetId);
         const response = await apiFetch(url, {
             method: "GET",
             credentials: "include",

--- a/services/dataFetcher.ts
+++ b/services/dataFetcher.ts
@@ -1,19 +1,32 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { Expense, SheetConfig, AddExpenseRequest, AddExpenseResponse, DeleteExpenseResponse } from "../src/types";
+import {
+    Expense,
+    SheetConfig,
+    AddExpenseRequest,
+    AddExpenseResponse,
+    DeleteExpenseResponse,
+} from "../src/types";
 import { api, mapRawExpenseToExpense } from "./api";
 import { useAuthState } from "../src/stores/AuthStore";
 import { useConfig } from "../src/stores/ConfigStore";
 import { EXPENSES_KEY, SHEET_CONFIG_KEY } from "./cacheKeys";
 import logger from "@/src/utils/logger";
+import {
+    getActiveSheetIdOrNull,
+    isSheetSelectionRequired,
+} from "@/src/utils/sheetSelection";
 
 // AppConfig hooks
 export const useGetSheetConfig = () => {
     const { isSignedIn } = useAuthState();
+    const selectedSheetId = getActiveSheetIdOrNull();
+    const canFetchSheetConfig =
+        isSignedIn && (!isSheetSelectionRequired() || !!selectedSheetId);
 
     return useQuery<SheetConfig, Error>({
-        queryKey: [SHEET_CONFIG_KEY],
-        queryFn: () => api.getSheetConfig(),
-        enabled: isSignedIn,
+        queryKey: [SHEET_CONFIG_KEY, selectedSheetId],
+        queryFn: () => api.getSheetConfig(selectedSheetId || undefined),
+        enabled: canFetchSheetConfig,
     });
 };
 
@@ -21,16 +34,21 @@ export const useGetSheetConfig = () => {
 export const useExpensesQuery = () => {
     const { user, isSignedIn } = useAuthState();
     const { sheetConfig } = useConfig();
+    const selectedSheetId = getActiveSheetIdOrNull();
 
     return useQuery<Expense[], Error>({
-        queryKey: [EXPENSES_KEY, user?.email],
+        queryKey: [EXPENSES_KEY, selectedSheetId, user?.email],
         queryFn: () => {
             if (!user?.email || !sheetConfig?.users) {
                 return Promise.resolve([]);
             }
             return api.getExpenses(user.email, sheetConfig.users);
         },
-        enabled: isSignedIn && !!user?.email && !!sheetConfig?.users,
+        enabled:
+            isSignedIn &&
+            !!selectedSheetId &&
+            !!user?.email &&
+            !!sheetConfig?.users,
         retry: 3,
     });
 };
@@ -45,7 +63,11 @@ export const useAddExpense = () => {
         onSuccess: (data) => {
             if (!sheetConfig?.users) {
                 queryClient.invalidateQueries({
-                    queryKey: [EXPENSES_KEY, user?.email],
+                    queryKey: [
+                        EXPENSES_KEY,
+                        getActiveSheetIdOrNull(),
+                        user?.email,
+                    ],
                 });
                 return;
             }
@@ -56,7 +78,7 @@ export const useAddExpense = () => {
             );
 
             queryClient.setQueryData<Expense[]>(
-                [EXPENSES_KEY, user?.email],
+                [EXPENSES_KEY, getActiveSheetIdOrNull(), user?.email],
                 (old) => {
                     if (!Array.isArray(old)) {
                         return [addedExpense];
@@ -79,7 +101,11 @@ export const useDeleteExpense = () => {
         onSuccess: (response) => {
             logger.log("Deleted expense response:", response);
             const { deletedTimestamp } = response;
-            const queryKey = [EXPENSES_KEY, user?.email];
+            const queryKey = [
+                EXPENSES_KEY,
+                getActiveSheetIdOrNull(),
+                user?.email,
+            ];
             queryClient.setQueryData<Expense[]>(
                 queryKey,
                 (old) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -87,7 +87,7 @@ export type AppConfig = {
 };
 
 export type SheetConfig = {
-    title?: string;
+    tripName?: string;
     startDate: string;
     endDate?: string;
     currencies: Record<string, number>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -87,6 +87,7 @@ export type AppConfig = {
 };
 
 export type SheetConfig = {
+    title?: string;
     startDate: string;
     endDate?: string;
     currencies: Record<string, number>;

--- a/src/utils/sheetSelection.ts
+++ b/src/utils/sheetSelection.ts
@@ -1,0 +1,89 @@
+export const SHEET_ID_STORAGE_KEY = "tripsplit_selected_sheet_id";
+
+export function getAvailableSheetIds(): string[] {
+    const rawSheetId = process.env.NEXT_PUBLIC_SHEET_ID;
+
+    if (!rawSheetId) {
+        return [];
+    }
+
+    try {
+        const parsed = JSON.parse(rawSheetId);
+        if (Array.isArray(parsed)) {
+            return parsed
+                .filter(
+                    (sheetId): sheetId is string => typeof sheetId === "string",
+                )
+                .map((sheetId) => sheetId.trim())
+                .filter(Boolean);
+        }
+        if (typeof parsed === "string") {
+            return [parsed.trim()].filter(Boolean);
+        }
+    } catch {
+        // Fall through to plain string/comma separated parsing.
+    }
+
+    return rawSheetId
+        .split(",")
+        .map((sheetId) => sheetId.trim())
+        .filter(Boolean);
+}
+
+export function isSheetSelectionRequired(): boolean {
+    return getAvailableSheetIds().length > 1;
+}
+
+export function getSelectedSheetId(): string {
+    const availableSheetIds = getAvailableSheetIds();
+
+    if (availableSheetIds.length === 0) {
+        throw new Error("Missing NEXT_PUBLIC_SHEET_ID env variable.");
+    }
+
+    if (typeof window === "undefined") {
+        return availableSheetIds[0];
+    }
+
+    if (availableSheetIds.length === 1) {
+        const [sheetId] = availableSheetIds;
+        window.localStorage.setItem(SHEET_ID_STORAGE_KEY, sheetId);
+        return sheetId;
+    }
+
+    const storedSheetId = window.localStorage.getItem(SHEET_ID_STORAGE_KEY);
+    if (storedSheetId && availableSheetIds.includes(storedSheetId)) {
+        return storedSheetId;
+    }
+
+    throw new Error("No Google Sheet selected.");
+}
+
+export function getStoredSheetId(): string | null {
+    if (typeof window === "undefined") {
+        return null;
+    }
+
+    const storedSheetId = window.localStorage.getItem(SHEET_ID_STORAGE_KEY);
+    const availableSheetIds = getAvailableSheetIds();
+
+    if (storedSheetId && availableSheetIds.includes(storedSheetId)) {
+        return storedSheetId;
+    }
+
+    return null;
+}
+
+export function getActiveSheetIdOrNull(): string | null {
+    const availableSheetIds = getAvailableSheetIds();
+
+    if (availableSheetIds.length === 1) {
+        return availableSheetIds[0];
+    }
+
+    return getStoredSheetId();
+}
+
+export function saveSelectedSheetId(sheetId: string) {
+    window.localStorage.setItem(SHEET_ID_STORAGE_KEY, sheetId);
+}


### PR DESCRIPTION
- Added multi-sheet support for NEXT_PUBLIC_SHEET_ID.
    - Supports a single string value.
    - Supports a JSON array like ["sheet_id_1","sheet_id_2"].
    - Also tolerates comma-separated IDs.
- Added sheet selection persistence.
    - Stores selected sheet ID in localStorage as tripsplit_selected_sheet_id.
    - Auto-selects and skips selection when only one sheet is configured.
    - Redirects authenticated users to /select-sheet when multiple sheets exist and no sheet is selected.
- Added /select-sheet page.
    - Lists configured Google Sheets.
    - Fetches each sheet’s setting data to display a readable title/fallback.
    - Clears sheet-specific React Query caches when switching sheets.
- Updated API and cache behavior.
    - All GCF requests now use the selected sheet ID.
    - Sheet config and expense query keys include the active sheet ID to avoid stale cross-sheet data.
- Updated drawer settings.
    - Added a standalone Switch Sheet action in the side drawer when multiple sheets are configured.
    - Kept Sheet 設定 focused on current sheet details and refresh.
- Updated docs.
    - Added README guidance for configuring multiple sheet IDs.