### PR TITLE
Feat: Auth error handle and update cache when the sheet id changed

### DIFF
--- a/app/select-sheet/page.tsx
+++ b/app/select-sheet/page.tsx
@@ -58,6 +58,10 @@ export default function SelectSheetPage() {
         })),
     });
 
+    /**
+     * Validates the target sheet before switching so the app does not persist
+     * a selection that cannot load its required config.
+     */
     const handleSelectSheet = async (sheetId: string) => {
         if (sheetId === selectedSheetId) {
             router.replace("/");
@@ -76,6 +80,7 @@ export default function SelectSheetPage() {
                     queryFn: () => api.getSheetConfig(sheetId),
                 }));
 
+            // Keep persisted query data aligned with the newly selected sheet.
             saveSelectedSheetId(sheetId);
             queryClient.setQueryData(sheetConfigQueryKey, sheetConfig);
             queryClient.removeQueries({ queryKey: [SHEET_CONFIG_KEY, null] });

--- a/app/select-sheet/page.tsx
+++ b/app/select-sheet/page.tsx
@@ -2,16 +2,19 @@
 
 import React from "react";
 import { useQueries, useQueryClient } from "@tanstack/react-query";
+import { persistQueryClientSave } from "@tanstack/react-query-persist-client";
 import { useRouter } from "next/navigation";
 import { AlertTriangle, CheckCircle2, RefreshCw, Table2 } from "lucide-react";
 import { api } from "@/services/api";
 import { EXPENSES_KEY, SHEET_CONFIG_KEY } from "@/services/cacheKeys";
+import { createIDBPersister } from "@/services/persister";
+import { Button } from "@/components/ui/button";
 import { SheetConfig } from "@/src/types";
 import {
-    getActiveSheetIdOrNull,
     getAvailableSheetIds,
     saveSelectedSheetId,
 } from "@/src/utils/sheetSelection";
+import { useSelectedSheetId } from "@/src/hooks/useSelectedSheetId";
 
 const formatSheetId = (sheetId: string) => {
     if (sheetId.length <= 12) {
@@ -39,7 +42,13 @@ export default function SelectSheetPage() {
     const router = useRouter();
     const queryClient = useQueryClient();
     const sheetIds = getAvailableSheetIds();
-    const selectedSheetId = getActiveSheetIdOrNull();
+    const selectedSheetId = useSelectedSheetId();
+    const [selectingSheetId, setSelectingSheetId] = React.useState<
+        string | null
+    >(null);
+    const [selectionError, setSelectionError] = React.useState<string | null>(
+        null,
+    );
 
     const sheetQueries = useQueries({
         queries: sheetIds.map((sheetId) => ({
@@ -49,11 +58,43 @@ export default function SelectSheetPage() {
         })),
     });
 
-    const handleSelectSheet = (sheetId: string) => {
-        saveSelectedSheetId(sheetId);
-        queryClient.removeQueries({ queryKey: [SHEET_CONFIG_KEY] });
-        queryClient.removeQueries({ queryKey: [EXPENSES_KEY] });
-        router.replace("/");
+    const handleSelectSheet = async (sheetId: string) => {
+        if (sheetId === selectedSheetId) {
+            router.replace("/");
+            return;
+        }
+
+        setSelectingSheetId(sheetId);
+        setSelectionError(null);
+
+        try {
+            const sheetConfigQueryKey = [SHEET_CONFIG_KEY, sheetId];
+            const sheetConfig =
+                queryClient.getQueryData<SheetConfig>(sheetConfigQueryKey) ??
+                (await queryClient.fetchQuery({
+                    queryKey: sheetConfigQueryKey,
+                    queryFn: () => api.getSheetConfig(sheetId),
+                }));
+
+            saveSelectedSheetId(sheetId);
+            queryClient.setQueryData(sheetConfigQueryKey, sheetConfig);
+            queryClient.removeQueries({ queryKey: [SHEET_CONFIG_KEY, null] });
+            queryClient.removeQueries({ queryKey: [EXPENSES_KEY] });
+            await persistQueryClientSave({
+                queryClient,
+                persister: createIDBPersister(),
+            });
+
+            router.replace("/");
+        } catch (error) {
+            setSelectionError(
+                error instanceof Error
+                    ? error.message
+                    : "Unable to load the selected sheet setting.",
+            );
+        } finally {
+            setSelectingSheetId(null);
+        }
     };
 
     return (
@@ -75,11 +116,13 @@ export default function SelectSheetPage() {
                         const isSelected = selectedSheetId === sheetId;
 
                         return (
-                            <button
+                            <Button
                                 key={sheetId}
+                                variant="outline"
                                 type="button"
                                 onClick={() => handleSelectSheet(sheetId)}
-                                className={`rounded-lg border bg-surface p-4 text-left shadow-sm transition hover:border-primary hover:shadow-md active:scale-[0.99] ${
+                                disabled={selectingSheetId !== null}
+                                className={`h-auto w-full justify-start rounded-lg bg-surface p-4 text-left shadow-sm hover:border-primary hover:bg-surface hover:shadow-md disabled:opacity-100 ${
                                     isSelected
                                         ? "border-primary ring-2 ring-primary/20"
                                         : "border-border"
@@ -105,6 +148,12 @@ export default function SelectSheetPage() {
                                                     className="shrink-0 text-primary"
                                                 />
                                             )}
+                                            {selectingSheetId === sheetId && (
+                                                <RefreshCw
+                                                    size={20}
+                                                    className="shrink-0 animate-spin text-primary"
+                                                />
+                                            )}
                                         </div>
                                         <p className="mt-1 font-mono text-xs text-text-muted">
                                             {formatSheetId(sheetId)}
@@ -126,7 +175,7 @@ export default function SelectSheetPage() {
                                         )}
                                     </div>
                                 </div>
-                            </button>
+                            </Button>
                         );
                     })}
                 </div>
@@ -134,6 +183,12 @@ export default function SelectSheetPage() {
                 {sheetIds.length === 0 && (
                     <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700">
                         Missing NEXT_PUBLIC_SHEET_ID env variable.
+                    </div>
+                )}
+
+                {selectionError && (
+                    <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+                        {selectionError}
                     </div>
                 )}
             </div>

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -7,14 +7,15 @@ import { LoginView } from "./LoginView";
 import { useAuthState } from "../src/stores/AuthStore";
 import {
     getAvailableSheetIds,
-    getStoredSheetId,
     saveSelectedSheetId,
 } from "@/src/utils/sheetSelection";
+import { useSelectedSheetId } from "@/src/hooks/useSelectedSheetId";
 
 export function AppShell({ children }: { children: React.ReactNode }) {
     const { isAuthInitialized, isSignedIn } = useAuthState();
     const pathname = usePathname();
     const router = useRouter();
+    const selectedSheetId = useSelectedSheetId();
     const [isSheetSelectionReady, setIsSheetSelectionReady] =
         React.useState(false);
 
@@ -35,7 +36,6 @@ export function AppShell({ children }: { children: React.ReactNode }) {
             return;
         }
 
-        const selectedSheetId = getStoredSheetId();
         if (!selectedSheetId) {
             setIsSheetSelectionReady(pathname === "/select-sheet");
             if (pathname !== "/select-sheet") {
@@ -45,7 +45,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
         }
 
         setIsSheetSelectionReady(true);
-    }, [isAuthInitialized, isSignedIn, pathname, router]);
+    }, [isAuthInitialized, isSignedIn, pathname, router, selectedSheetId]);
 
     if (!isAuthInitialized) {
         return (

--- a/components/LoginView.tsx
+++ b/components/LoginView.tsx
@@ -1,9 +1,40 @@
 "use client";
 
 import React from "react";
+import { AlertTriangle } from "lucide-react";
 import { SignInManager } from "./SignInManager";
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import {
+    AuthErrorNotice,
+    consumeAuthErrorNotice,
+} from "@/src/utils/authError";
 
 export function LoginView() {
+    const [authNotice, setAuthNotice] =
+        React.useState<AuthErrorNotice | null>(null);
+
+    React.useEffect(() => {
+        const notice = consumeAuthErrorNotice();
+        if (!notice) {
+            return;
+        }
+
+        setAuthNotice(notice);
+
+        const url = new URL(window.location.href);
+        url.searchParams.delete("auth_error");
+        url.searchParams.delete("message");
+        window.history.replaceState({}, "", url.toString());
+    }, []);
+
     return (
         <div className="min-h-dvh flex items-center justify-center bg-background px-4 transition-colors">
             <div className="max-w-md w-full bg-surface rounded-xl shadow-lg p-8 animate-in fade-in zoom-in duration-300 border border-border">
@@ -22,6 +53,32 @@ export function LoginView() {
                     <SignInManager />
                 </div>
             </div>
+
+            <AlertDialog
+                open={!!authNotice}
+                onOpenChange={(open) => {
+                    if (!open) {
+                        setAuthNotice(null);
+                    }
+                }}
+            >
+                <AlertDialogContent className="bg-surface">
+                    <AlertDialogHeader className="gap-3">
+                        <div className="flex size-10 items-center justify-center rounded-full bg-yellow-100 text-yellow-700">
+                            <AlertTriangle className="size-5" />
+                        </div>
+                        <AlertDialogTitle>{authNotice?.title}</AlertDialogTitle>
+                        <AlertDialogDescription>
+                            {authNotice?.message}
+                        </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogAction onClick={() => setAuthNotice(null)}>
+                            Got it
+                        </AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
         </div>
     );
 }

--- a/components/ui/alert-dialog.tsx
+++ b/components/ui/alert-dialog.tsx
@@ -1,0 +1,166 @@
+import * as React from "react";
+import { AlertDialog as AlertDialogPrimitive } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+import { buttonVariants } from "@/components/ui/button";
+
+function AlertDialog({
+    ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
+    return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />;
+}
+
+function AlertDialogTrigger({
+    ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
+    return (
+        <AlertDialogPrimitive.Trigger
+            data-slot="alert-dialog-trigger"
+            {...props}
+        />
+    );
+}
+
+function AlertDialogPortal({
+    ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
+    return (
+        <AlertDialogPrimitive.Portal
+            data-slot="alert-dialog-portal"
+            {...props}
+        />
+    );
+}
+
+function AlertDialogOverlay({
+    className,
+    ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+    return (
+        <AlertDialogPrimitive.Overlay
+            data-slot="alert-dialog-overlay"
+            className={cn(
+                "fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+                className,
+            )}
+            {...props}
+        />
+    );
+}
+
+function AlertDialogContent({
+    className,
+    ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Content>) {
+    return (
+        <AlertDialogPortal>
+            <AlertDialogOverlay />
+            <AlertDialogPrimitive.Content
+                data-slot="alert-dialog-content"
+                className={cn(
+                    "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+                    className,
+                )}
+                {...props}
+            />
+        </AlertDialogPortal>
+    );
+}
+
+function AlertDialogHeader({
+    className,
+    ...props
+}: React.ComponentProps<"div">) {
+    return (
+        <div
+            data-slot="alert-dialog-header"
+            className={cn("flex flex-col gap-2", className)}
+            {...props}
+        />
+    );
+}
+
+function AlertDialogFooter({
+    className,
+    ...props
+}: React.ComponentProps<"div">) {
+    return (
+        <div
+            data-slot="alert-dialog-footer"
+            className={cn(
+                "-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 sm:flex-row sm:justify-end",
+                className,
+            )}
+            {...props}
+        />
+    );
+}
+
+function AlertDialogTitle({
+    className,
+    ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+    return (
+        <AlertDialogPrimitive.Title
+            data-slot="alert-dialog-title"
+            className={cn(
+                "font-heading text-base leading-none font-medium",
+                className,
+            )}
+            {...props}
+        />
+    );
+}
+
+function AlertDialogDescription({
+    className,
+    ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+    return (
+        <AlertDialogPrimitive.Description
+            data-slot="alert-dialog-description"
+            className={cn("text-sm text-muted-foreground", className)}
+            {...props}
+        />
+    );
+}
+
+function AlertDialogAction({
+    className,
+    ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Action>) {
+    return (
+        <AlertDialogPrimitive.Action
+            data-slot="alert-dialog-action"
+            className={cn(buttonVariants(), className)}
+            {...props}
+        />
+    );
+}
+
+function AlertDialogCancel({
+    className,
+    ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel>) {
+    return (
+        <AlertDialogPrimitive.Cancel
+            data-slot="alert-dialog-cancel"
+            className={cn(buttonVariants({ variant: "outline" }), className)}
+            {...props}
+        />
+    );
+}
+
+export {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogOverlay,
+    AlertDialogPortal,
+    AlertDialogTitle,
+    AlertDialogTrigger,
+};

--- a/services/dataFetcher.ts
+++ b/services/dataFetcher.ts
@@ -15,11 +15,12 @@ import {
     getActiveSheetIdOrNull,
     isSheetSelectionRequired,
 } from "@/src/utils/sheetSelection";
+import { useSelectedSheetId } from "@/src/hooks/useSelectedSheetId";
 
 // AppConfig hooks
 export const useGetSheetConfig = () => {
     const { isSignedIn } = useAuthState();
-    const selectedSheetId = getActiveSheetIdOrNull();
+    const selectedSheetId = useSelectedSheetId();
     const canFetchSheetConfig =
         isSignedIn && (!isSheetSelectionRequired() || !!selectedSheetId);
 
@@ -34,7 +35,7 @@ export const useGetSheetConfig = () => {
 export const useExpensesQuery = () => {
     const { user, isSignedIn } = useAuthState();
     const { sheetConfig } = useConfig();
-    const selectedSheetId = getActiveSheetIdOrNull();
+    const selectedSheetId = useSelectedSheetId();
 
     return useQuery<Expense[], Error>({
         queryKey: [EXPENSES_KEY, selectedSheetId, user?.email],

--- a/src/hooks/useSelectedSheetId.ts
+++ b/src/hooks/useSelectedSheetId.ts
@@ -4,6 +4,7 @@ import {
     SHEET_ID_CHANGE_EVENT,
 } from "@/src/utils/sheetSelection";
 
+// Subscribe to both in-page updates and cross-tab localStorage changes.
 const subscribe = (onStoreChange: () => void) => {
     window.addEventListener(SHEET_ID_CHANGE_EVENT, onStoreChange);
     window.addEventListener("storage", onStoreChange);
@@ -18,6 +19,10 @@ const getSnapshot = () => getActiveSheetIdOrNull();
 
 const getServerSnapshot = () => null;
 
+/**
+ * Reads the active Google Sheet ID as reactive state.
+ * Components using this hook update immediately after saveSelectedSheetId runs.
+ */
 export function useSelectedSheetId() {
     return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 }

--- a/src/hooks/useSelectedSheetId.ts
+++ b/src/hooks/useSelectedSheetId.ts
@@ -1,0 +1,23 @@
+import { useSyncExternalStore } from "react";
+import {
+    getActiveSheetIdOrNull,
+    SHEET_ID_CHANGE_EVENT,
+} from "@/src/utils/sheetSelection";
+
+const subscribe = (onStoreChange: () => void) => {
+    window.addEventListener(SHEET_ID_CHANGE_EVENT, onStoreChange);
+    window.addEventListener("storage", onStoreChange);
+
+    return () => {
+        window.removeEventListener(SHEET_ID_CHANGE_EVENT, onStoreChange);
+        window.removeEventListener("storage", onStoreChange);
+    };
+};
+
+const getSnapshot = () => getActiveSheetIdOrNull();
+
+const getServerSnapshot = () => null;
+
+export function useSelectedSheetId() {
+    return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}

--- a/src/stores/AuthStore.tsx
+++ b/src/stores/AuthStore.tsx
@@ -13,6 +13,7 @@ import { User } from "../types";
 import { clearExpensesCache } from "./ExpensesStore";
 import { api } from "../../services/api";
 import logger from "@/src/utils/logger";
+import { hasAuthErrorSearchParam } from "@/src/utils/authError";
 
 type AuthState = {
     isSignedIn: boolean;
@@ -39,6 +40,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
     useEffect(() => {
         const checkCookie = async () => {
+            if (hasAuthErrorSearchParam()) {
+                clearUser();
+                clearExpensesCache();
+                return;
+            }
+
             const isLoggedIn = Cookies.get("is_logged_in");
             logger.log("is_logged_in cookie", isLoggedIn);
 

--- a/src/utils/authError.ts
+++ b/src/utils/authError.ts
@@ -42,6 +42,11 @@ export const defaultUnauthorizedNotice: AuthErrorNotice = {
         "This Google account is not authorized to access TripSplit. Please sign in with an allowed account.",
 };
 
+/**
+ * Returns the auth error notice that should be shown once on the login screen.
+ * Session storage wins so redirects can preserve a notice even if query params
+ * are later removed from the URL.
+ */
 export function consumeAuthErrorNotice(): AuthErrorNotice | null {
     if (typeof window === "undefined") {
         return null;
@@ -72,6 +77,10 @@ export function consumeAuthErrorNotice(): AuthErrorNotice | null {
     return null;
 }
 
+/**
+ * Detects auth-error redirects before the normal cookie check runs.
+ * This keeps a failed OAuth redirect from reusing stale local user state.
+ */
 export function hasAuthErrorSearchParam() {
     if (typeof window === "undefined") {
         return false;

--- a/src/utils/authError.ts
+++ b/src/utils/authError.ts
@@ -1,0 +1,81 @@
+"use client";
+
+import { USER_STORAGE_KEY } from "@/services/cacheKeys";
+
+const AUTH_ERROR_STORAGE_KEY = "tripsplit_auth_error";
+
+export type AuthErrorNotice = {
+    title: string;
+    message: string;
+};
+
+const authErrorNotices: Record<string, AuthErrorNotice> = {
+    oauth_denied: {
+        title: "Sign-in cancelled",
+        message: "Google sign-in was cancelled. Please try again to continue.",
+    },
+    token_exchange_failed: {
+        title: "Sign-in failed",
+        message:
+            "We could not complete Google sign-in. Please try again in a moment.",
+    },
+    userinfo_failed: {
+        title: "Sign-in failed",
+        message:
+            "We could not load your Google account details. Please try again.",
+    },
+    email_unavailable: {
+        title: "Email unavailable",
+        message:
+            "Your Google account did not provide an email address. Please use another account.",
+    },
+    unauthorized_email: {
+        title: "Account not allowed",
+        message:
+            "This Google account is not authorized to access TripSplit. Please sign in with an allowed account.",
+    },
+};
+
+export const defaultUnauthorizedNotice: AuthErrorNotice = {
+    title: "Account not allowed",
+    message:
+        "This Google account is not authorized to access TripSplit. Please sign in with an allowed account.",
+};
+
+export function consumeAuthErrorNotice(): AuthErrorNotice | null {
+    if (typeof window === "undefined") {
+        return null;
+    }
+
+    const params = new URLSearchParams(window.location.search);
+    const authError = params.get("auth_error");
+    const queryMessage = params.get("message");
+    const storedNotice = window.sessionStorage.getItem(AUTH_ERROR_STORAGE_KEY);
+
+    if (storedNotice) {
+        window.sessionStorage.removeItem(AUTH_ERROR_STORAGE_KEY);
+        try {
+            return JSON.parse(storedNotice) as AuthErrorNotice;
+        } catch {
+            return defaultUnauthorizedNotice;
+        }
+    }
+
+    if (authError) {
+        const notice = authErrorNotices[authError] || defaultUnauthorizedNotice;
+        return {
+            ...notice,
+            message: queryMessage || notice.message,
+        };
+    }
+
+    return null;
+}
+
+export function hasAuthErrorSearchParam() {
+    if (typeof window === "undefined") {
+        return false;
+    }
+
+    return new URLSearchParams(window.location.search).has("auth_error");
+}

--- a/src/utils/sheetSelection.ts
+++ b/src/utils/sheetSelection.ts
@@ -1,4 +1,5 @@
 export const SHEET_ID_STORAGE_KEY = "tripsplit_selected_sheet_id";
+export const SHEET_ID_CHANGE_EVENT = "tripsplit_selected_sheet_id_change";
 
 export function getAvailableSheetIds(): string[] {
     const rawSheetId = process.env.NEXT_PUBLIC_SHEET_ID;
@@ -86,4 +87,5 @@ export function getActiveSheetIdOrNull(): string | null {
 
 export function saveSelectedSheetId(sheetId: string) {
     window.localStorage.setItem(SHEET_ID_STORAGE_KEY, sheetId);
+    window.dispatchEvent(new CustomEvent(SHEET_ID_CHANGE_EVENT));
 }

--- a/src/utils/sheetSelection.ts
+++ b/src/utils/sheetSelection.ts
@@ -85,6 +85,11 @@ export function getActiveSheetIdOrNull(): string | null {
     return getStoredSheetId();
 }
 
+/**
+ * Persists the user's selected sheet and notifies same-page subscribers.
+ * The native storage event only fires in other tabs, so the custom event keeps
+ * the current React tree in sync too.
+ */
 export function saveSelectedSheetId(sheetId: string) {
     window.localStorage.setItem(SHEET_ID_STORAGE_KEY, sheetId);
     window.dispatchEvent(new CustomEvent(SHEET_ID_CHANGE_EVENT));


### PR DESCRIPTION
## Summary

  This branch improves auth-error handling and fixes selected-sheet state synchronization so the app reacts correctly when auth redirects fail or when users switch between configured sheets.

## Changes

- Added auth error detection from `auth_error` URL params.
  - Clears the current user and expense cache when an auth-error redirect is detected.
  - Prevents the app from treating a failed OAuth redirect as a valid signed-in session.

- Added user-facing auth error messaging on the login screen.
  - Shows an alert dialog for known auth failures such as:
    - cancelled Google sign-in
    - token exchange failure
    - user info loading failure
    - missing email
    - unauthorized email/account
  - Supports a custom `message` query param when provided.
  - Removes auth error params from the URL after displaying the notice.

- Added a reusable `AlertDialog` UI component based on Radix primitives.

- Added `useSelectedSheetId()` hook backed by `useSyncExternalStore`.
  - Keeps selected sheet state reactive across components.
  - Listens for both local sheet-selection changes and browser `storage` events.

- Updated sheet selection flow.
  - Fetches and validates the selected sheet config before switching sheets.
  - Persists the updated React Query cache after selection.
  - Clears stale default sheet config and expense queries after switching.
  - Shows loading state while a sheet is being selected.
  - Shows an inline error if the selected sheet config cannot be loaded.

- Updated app shell and data fetching to use reactive selected-sheet state.
  - Prevents stale sheet IDs from being used after switching sheets.
  - Keeps redirect logic and query keys aligned with the current selected sheet.