### PR TITLE
Feat: Add Shimanami travel book

### DIFF
--- a/app/2026-shimanami/page.tsx
+++ b/app/2026-shimanami/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+import { ShimanamiTravelBook } from "@/components/travel-books/shimanami/ShimanamiTravelBook";
+import { SHIMANAMI_TRAVEL_BOOK } from "@/src/travel/registry";
+
+export const metadata: Metadata = {
+    title: SHIMANAMI_TRAVEL_BOOK.metadata.title,
+    description: SHIMANAMI_TRAVEL_BOOK.metadata.description,
+};
+
+export default function ShimanamiTravelBookPage() {
+    return <ShimanamiTravelBook />;
+}

--- a/app/plan/page.tsx
+++ b/app/plan/page.tsx
@@ -2,6 +2,7 @@
 
 import React from "react";
 import { FileText, Table, ExternalLink, Sparkle } from "lucide-react"; // 使用 lucide-react 作為圖示庫
+import { TravelBookList } from "@/components/travel-books/TravelBookList";
 import { useConfig } from "../../src/stores/ConfigStore";
 import _isEmpty from "lodash/isEmpty";
 
@@ -24,6 +25,8 @@ const PlanPage = () => {
 
     return (
         <div className="flex flex-col gap-5 p-4 mx-auto pb-20">
+            <TravelBookList resources={resources} />
+
             {/* External Resources Section */}
             {!_isEmpty(resources) && (
                 <section>

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -10,16 +10,22 @@ import {
     saveSelectedSheetId,
 } from "@/src/utils/sheetSelection";
 import { useSelectedSheetId } from "@/src/hooks/useSelectedSheetId";
+import { isPublicTravelBookPath } from "@/src/travel/registry";
 
 export function AppShell({ children }: { children: React.ReactNode }) {
     const { isAuthInitialized, isSignedIn } = useAuthState();
     const pathname = usePathname();
     const router = useRouter();
     const selectedSheetId = useSelectedSheetId();
+    const isPublicTravelBook = isPublicTravelBookPath(pathname);
     const [isSheetSelectionReady, setIsSheetSelectionReady] =
         React.useState(false);
 
     React.useEffect(() => {
+        if (isPublicTravelBook) {
+            return;
+        }
+
         if (!isAuthInitialized || !isSignedIn) {
             return;
         }
@@ -45,7 +51,18 @@ export function AppShell({ children }: { children: React.ReactNode }) {
         }
 
         setIsSheetSelectionReady(true);
-    }, [isAuthInitialized, isSignedIn, pathname, router, selectedSheetId]);
+    }, [
+        isAuthInitialized,
+        isPublicTravelBook,
+        isSignedIn,
+        pathname,
+        router,
+        selectedSheetId,
+    ]);
+
+    if (isPublicTravelBook) {
+        return <>{children}</>;
+    }
 
     if (!isAuthInitialized) {
         return (

--- a/components/travel-books/TravelBookCard.tsx
+++ b/components/travel-books/TravelBookCard.tsx
@@ -1,0 +1,37 @@
+import Link from "next/link";
+import { ArrowRight, Bike } from "lucide-react";
+import type { TravelBookDefinition } from "@/src/travel/types";
+
+export function TravelBookCard({
+    travelBook,
+}: {
+    travelBook: TravelBookDefinition;
+}) {
+    return (
+        <Link
+            href={travelBook.path}
+            className="group relative block overflow-hidden rounded-[1.5rem] bg-[#126b8a] p-5 text-white shadow-lg transition-transform active:scale-[0.98]"
+        >
+            <div className="absolute -right-8 -top-10 size-36 rounded-full border-[18px] border-white/10" />
+            <div className="relative">
+                <div className="flex items-center gap-2 text-xs font-bold tracking-[0.15em] text-[#f2c94c]">
+                    <Bike size={16} />
+                    {travelBook.eyebrow}
+                </div>
+                <h2 className="mt-4 text-2xl font-black tracking-tight">
+                    {travelBook.title}
+                </h2>
+                <p className="mt-1 text-sm text-[#d9eef3]">
+                    {travelBook.dateRange} · {travelBook.destinations}
+                </p>
+                <span className="mt-5 flex items-center gap-2 text-sm font-bold">
+                    開啟旅行手冊
+                    <ArrowRight
+                        size={16}
+                        className="transition-transform group-hover:translate-x-1"
+                    />
+                </span>
+            </div>
+        </Link>
+    );
+}

--- a/components/travel-books/TravelBookList.tsx
+++ b/components/travel-books/TravelBookList.tsx
@@ -1,0 +1,26 @@
+import { TravelBookCard } from "./TravelBookCard";
+import { getTravelBooksForResources } from "@/src/travel/registry";
+import type { TravelResource } from "@/src/travel/types";
+
+export function TravelBookList({
+    resources,
+}: {
+    resources: readonly TravelResource[];
+}) {
+    const travelBooks = getTravelBooksForResources(resources);
+
+    if (travelBooks.length === 0) {
+        return null;
+    }
+
+    return (
+        <section className="grid grid-cols-1 gap-4" aria-label="旅行手冊">
+            {travelBooks.map((travelBook) => (
+                <TravelBookCard
+                    key={travelBook.id}
+                    travelBook={travelBook}
+                />
+            ))}
+        </section>
+    );
+}

--- a/components/travel-books/shimanami/ShimanamiTravelBook.tsx
+++ b/components/travel-books/shimanami/ShimanamiTravelBook.tsx
@@ -1,0 +1,561 @@
+"use client";
+
+import * as React from "react";
+import {
+    AlertTriangle,
+    Bike,
+    BusFront,
+    Check,
+    ChevronDown,
+    ChevronLeft,
+    ChevronRight,
+    CircleHelp,
+    CloudRain,
+    ExternalLink,
+    FileText,
+    Flag,
+    Footprints,
+    Hotel,
+    Info,
+    MapPin,
+    Navigation,
+    Route,
+    ShieldAlert,
+    ShoppingBag,
+    Sun,
+    Utensils,
+    WifiOff,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import {
+    getDateInTimeZone,
+    getEffectiveDayIndex,
+} from "@/src/travel/date";
+import {
+    PREPARATION_ITEMS,
+    SHIMANAMI_TRIP,
+    type ShimanamiDay,
+    type ShimanamiEvent,
+    type ShimanamiEventType,
+} from "@/src/travel/shimanami";
+import { SHIMANAMI_TRAVEL_BOOK } from "@/src/travel/registry";
+
+const EVENT_ICON: Record<ShimanamiEventType, React.ComponentType<{ className?: string }>> = {
+    transport: BusFront,
+    activity: Footprints,
+    food: Utensils,
+    lodging: Hotel,
+    cycling: Bike,
+    task: Check,
+    reminder: ShieldAlert,
+};
+
+const STATUS_LABEL = {
+    confirmed: "已確認",
+    "to-confirm": "待確認",
+    cancelled: "已取消",
+    informational: "行程資訊",
+};
+
+const PRIORITY_LABEL = {
+    required: "必要",
+    recommended: "建議",
+    optional: "可選",
+};
+
+function EventCard({ event }: { event: ShimanamiEvent }) {
+    const Icon = EVENT_ICON[event.type];
+    const isOptional = event.priority === "optional";
+
+    return (
+        <article
+            className={cn(
+                "relative rounded-[1.35rem] border bg-white p-4 shadow-[0_10px_28px_rgba(19,50,59,0.06)]",
+                isOptional ? "border-dashed border-[#9cb9c2] bg-[#f8fbfb]" : "border-[#d6e3e6]",
+                event.status === "cancelled" && "opacity-55",
+            )}
+        >
+            <div className="flex items-start gap-3">
+                <div className="mt-0.5 flex size-10 shrink-0 items-center justify-center rounded-full bg-[#d9eef3] text-[#126b8a]">
+                    <Icon className="size-[18px]" />
+                </div>
+                <div className="min-w-0 flex-1">
+                    <div className="mb-1 flex flex-wrap items-center gap-2">
+                        <span className="font-mono text-xs font-bold tracking-wide text-[#126b8a]">
+                            {event.time}
+                        </span>
+                        {event.priority && (
+                            <span
+                                className={cn(
+                                    "rounded-full px-2 py-0.5 text-[10px] font-bold tracking-wide",
+                                    event.priority === "required" && "bg-[#17323b] text-white",
+                                    event.priority === "recommended" && "bg-[#d9eef3] text-[#174d60]",
+                                    event.priority === "optional" && "border border-[#9cb9c2] text-[#506a73]",
+                                )}
+                            >
+                                {PRIORITY_LABEL[event.priority]}
+                            </span>
+                        )}
+                        {event.status && event.status !== "informational" && (
+                            <span
+                                className={cn(
+                                    "rounded-full px-2 py-0.5 text-[10px] font-bold",
+                                    event.status === "confirmed" && "bg-[#dcefe6] text-[#27664c]",
+                                    event.status === "to-confirm" && "bg-[#fff1bf] text-[#795d00]",
+                                    event.status === "cancelled" && "bg-[#eee] text-[#666]",
+                                )}
+                            >
+                                {STATUS_LABEL[event.status]}
+                            </span>
+                        )}
+                    </div>
+                    <h3 className="text-[17px] font-extrabold leading-snug text-[#17323b]">
+                        {event.title}
+                    </h3>
+                    {event.location && (
+                        <p className="mt-1 flex items-center gap-1 text-xs font-medium text-[#607983]">
+                            <MapPin className="size-3.5" />
+                            {event.location}
+                        </p>
+                    )}
+                    {event.description && (
+                        <p className="mt-2 text-sm leading-6 text-[#506a73]">{event.description}</p>
+                    )}
+                    {event.warning && (
+                        <div className="mt-3 flex gap-2 rounded-xl bg-[#fff0ed] p-3 text-xs font-semibold leading-5 text-[#9b3f36]">
+                            <AlertTriangle className="mt-0.5 size-4 shrink-0" />
+                            <span>{event.warning}</span>
+                        </div>
+                    )}
+                    {event.links && (
+                        <div className="mt-3 flex flex-wrap gap-2">
+                            {event.links.map((link) => (
+                                <Button
+                                    key={link.url}
+                                    asChild
+                                    variant="outline"
+                                    className="h-10 rounded-full border-[#b8d1d8] bg-white px-3 text-xs font-bold text-[#126b8a] hover:bg-[#eaf5f7]"
+                                >
+                                    <a href={link.url} target="_blank" rel="noopener noreferrer">
+                                        {link.kind === "map" ? (
+                                            <Navigation className="size-3.5" />
+                                        ) : (
+                                            <ExternalLink className="size-3.5" />
+                                        )}
+                                        {link.label}
+                                    </a>
+                                </Button>
+                            ))}
+                        </div>
+                    )}
+                </div>
+            </div>
+        </article>
+    );
+}
+
+function CyclingProgress({ cycling }: { cycling: NonNullable<ShimanamiDay["cycling"]> }) {
+    return (
+        <section className="overflow-hidden rounded-[1.5rem] bg-[#17323b] p-5 text-white">
+            <div className="flex items-center gap-2 text-[#f2c94c]">
+                <Route className="size-4" />
+                <span className="text-xs font-extrabold tracking-[0.16em]">
+                    {cycling.label}
+                </span>
+            </div>
+            <p className="mt-3 text-xl font-black leading-snug">{cycling.route}</p>
+            <div className="mt-4 grid grid-cols-2 gap-3 text-sm">
+                <div>
+                    <p className="text-xs text-[#a9c7d0]">預計距離</p>
+                    <p className="mt-1 font-bold">{cycling.distance}</p>
+                </div>
+                <div>
+                    <p className="text-xs text-[#a9c7d0]">安全時段</p>
+                    <p className="mt-1 font-bold">{cycling.rideWindow}</p>
+                </div>
+            </div>
+            <div className="mt-5" aria-label={`三日騎行進度 ${cycling.progress}%`}>
+                <div className="mb-2 flex justify-between text-[10px] font-bold tracking-wider text-[#a9c7d0]">
+                    <span>{cycling.startLabel}</span>
+                    <span>{cycling.endLabel}</span>
+                </div>
+                <div className="h-2 rounded-full bg-white/15">
+                    <div
+                        className="h-full rounded-full bg-[#f2c94c] transition-[width] duration-500 motion-reduce:transition-none"
+                        style={{ width: `${cycling.progress}%` }}
+                    />
+                </div>
+            </div>
+        </section>
+    );
+}
+
+function Checklist({
+    items,
+    storageKey,
+    title,
+}: {
+    items: readonly { id: string; label: string }[];
+    storageKey: string;
+    title: string;
+}) {
+    const [checked, setChecked] = React.useState<string[]>([]);
+
+    React.useEffect(() => {
+        try {
+            setChecked(JSON.parse(localStorage.getItem(storageKey) || "[]"));
+        } catch {
+            setChecked([]);
+        }
+    }, [storageKey]);
+
+    const toggle = (id: string) => {
+        setChecked((current) => {
+            const next = current.includes(id)
+                ? current.filter((item) => item !== id)
+                : [...current, id];
+            localStorage.setItem(storageKey, JSON.stringify(next));
+            return next;
+        });
+    };
+
+    return (
+        <details className="group rounded-[1.5rem] border border-[#d6e3e6] bg-white">
+            <summary className="flex min-h-14 cursor-pointer list-none items-center justify-between gap-3 p-4 font-extrabold text-[#17323b] [&::-webkit-details-marker]:hidden">
+                <span className="flex items-center gap-3">
+                    <span className="flex size-9 items-center justify-center rounded-full bg-[#fff1bf] text-[#795d00]">
+                        <ShoppingBag className="size-4" />
+                    </span>
+                    {title}
+                    <span className="font-mono text-xs text-[#607983]">
+                        {checked.length}/{items.length}
+                    </span>
+                </span>
+                <ChevronDown className="size-5 transition-transform group-open:rotate-180" />
+            </summary>
+            <div className="space-y-1 border-t border-[#e2ebed] p-3">
+                {items.map((item) => {
+                    const active = checked.includes(item.id);
+                    return (
+                        <label
+                            key={item.id}
+                            className="flex min-h-12 cursor-pointer items-center gap-3 rounded-xl px-2 py-2 hover:bg-[#f2f7f8]"
+                        >
+                            <input
+                                type="checkbox"
+                                checked={active}
+                                onChange={() => toggle(item.id)}
+                                className="sr-only"
+                            />
+                            <span
+                                className={cn(
+                                    "flex size-6 shrink-0 items-center justify-center rounded-md border-2",
+                                    active
+                                        ? "border-[#126b8a] bg-[#126b8a] text-white"
+                                        : "border-[#9cb9c2] bg-white",
+                                )}
+                            >
+                                {active && <Check className="size-4" strokeWidth={3} />}
+                            </span>
+                            <span
+                                className={cn(
+                                    "text-sm font-medium text-[#294852]",
+                                    active && "text-[#7c9096] line-through",
+                                )}
+                            >
+                                {item.label}
+                            </span>
+                        </label>
+                    );
+                })}
+            </div>
+        </details>
+    );
+}
+
+export function ShimanamiTravelBook() {
+    const trip = SHIMANAMI_TRIP;
+    const storageKey = `${SHIMANAMI_TRAVEL_BOOK.id}-preparation`;
+    const days = trip.days;
+    const [effectiveIndex, setEffectiveIndex] = React.useState(() =>
+        getEffectiveDayIndex(days, new Date(), trip.timezone),
+    );
+    const [selectedIndex, setSelectedIndex] = React.useState(effectiveIndex);
+    const [manualSelection, setManualSelection] = React.useState(false);
+    const [offline, setOffline] = React.useState(false);
+    const dateStripRef = React.useRef<HTMLDivElement>(null);
+
+    const refreshEffectiveDay = React.useCallback(() => {
+        const nextIndex = getEffectiveDayIndex(days, new Date(), trip.timezone);
+        setEffectiveIndex(nextIndex);
+        if (!manualSelection) {
+            setSelectedIndex(nextIndex);
+        }
+    }, [days, manualSelection, trip.timezone]);
+
+    React.useEffect(() => {
+        const onVisibility = () => {
+            if (document.visibilityState === "visible") refreshEffectiveDay();
+        };
+        const onNetwork = () => setOffline(!navigator.onLine);
+        const timer = window.setInterval(refreshEffectiveDay, 60_000);
+        onNetwork();
+        document.addEventListener("visibilitychange", onVisibility);
+        window.addEventListener("online", onNetwork);
+        window.addEventListener("offline", onNetwork);
+        return () => {
+            window.clearInterval(timer);
+            document.removeEventListener("visibilitychange", onVisibility);
+            window.removeEventListener("online", onNetwork);
+            window.removeEventListener("offline", onNetwork);
+        };
+    }, [refreshEffectiveDay]);
+
+    React.useEffect(() => {
+        const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+        dateStripRef.current
+            ?.querySelector<HTMLElement>(`[data-day-index="${selectedIndex}"]`)
+            ?.scrollIntoView({
+                behavior: reduceMotion ? "auto" : "smooth",
+                inline: "center",
+                block: "nearest",
+            });
+    }, [selectedIndex]);
+
+    const day = days[selectedIndex];
+    const currentTripDate = getDateInTimeZone(new Date(), trip.timezone);
+    const beforeTrip = currentTripDate < trip.startDate;
+    const afterTrip = currentTripDate > trip.endDate;
+
+    const selectDay = (index: number) => {
+        setSelectedIndex(index);
+        setManualSelection(index !== effectiveIndex);
+    };
+
+    const returnToToday = () => {
+        setManualSelection(false);
+        setSelectedIndex(effectiveIndex);
+    };
+
+    return (
+        <main lang="zh-Hant" className="min-h-full bg-[#f7faf8] text-[#17323b]">
+            <header className="relative overflow-hidden bg-[#126b8a] px-5 pb-7 pt-8 text-white">
+                <div
+                    aria-hidden="true"
+                    className="absolute -right-14 -top-20 size-64 rounded-full border-[28px] border-white/10"
+                />
+                <div
+                    aria-hidden="true"
+                    className="absolute -bottom-10 left-1/3 h-24 w-64 rotate-[-8deg] rounded-[100%] border-t-4 border-dashed border-[#f2c94c]/70"
+                />
+                <div className="relative mx-auto max-w-xl">
+                    <div className="flex items-center justify-between gap-3">
+                        <p className="font-mono text-[11px] font-bold tracking-[0.18em] text-[#cce7ed]">
+                            TRAVEL BOOK · {trip.year}
+                        </p>
+                        <span className="rounded-full bg-white/12 px-3 py-1 font-mono text-[10px] font-bold">
+                            {trip.timezoneLabel}
+                        </span>
+                    </div>
+                    <h1 className="mt-5 max-w-sm text-[2.55rem] font-black leading-[0.98] tracking-[-0.05em]">
+                        {trip.heroTitle}
+                        <br />
+                        <span className="text-[#f2c94c]">{trip.heroAccent}</span>
+                    </h1>
+                    <div className="mt-5 flex items-center gap-2 text-sm font-semibold text-[#d9eef3]">
+                        <MapPin className="size-4" />
+                        {trip.routeSummary}
+                    </div>
+                </div>
+            </header>
+
+            <div className="sticky top-0 z-20 border-b border-[#c8dce1] bg-[#f7faf8]/95 backdrop-blur-md">
+                <div
+                    ref={dateStripRef}
+                    className="mx-auto flex max-w-xl gap-2 overflow-x-auto px-4 py-3 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+                    aria-label="旅程日期"
+                >
+                    {days.map((item, index) => (
+                        <button
+                            key={item.id}
+                            data-day-index={index}
+                            type="button"
+                            onClick={() => selectDay(index)}
+                            aria-pressed={index === selectedIndex}
+                            className={cn(
+                                "relative min-w-[64px] rounded-2xl border px-3 py-2 text-center transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#126b8a] focus-visible:ring-offset-2",
+                                index === selectedIndex
+                                    ? "border-[#17323b] bg-[#17323b] text-white"
+                                    : "border-[#d6e3e6] bg-white text-[#506a73]",
+                            )}
+                        >
+                            <span className="block font-mono text-[10px] font-bold">{item.dayLabel}</span>
+                            <span className="mt-0.5 block text-sm font-black">
+                                {Number(item.date.slice(8))}
+                            </span>
+                            {index === effectiveIndex && (
+                                <span
+                                    className="absolute -right-1 -top-1 size-3 rounded-full border-2 border-[#f7faf8] bg-[#f2c94c]"
+                                    aria-label="目前旅程日"
+                                />
+                            )}
+                        </button>
+                    ))}
+                </div>
+            </div>
+
+            <div className="mx-auto max-w-xl space-y-5 px-4 pb-12 pt-5">
+                {offline && (
+                    <div className="flex items-center gap-2 rounded-xl bg-[#fff1bf] px-3 py-2 text-xs font-bold text-[#795d00]">
+                        <WifiOff className="size-4" />
+                        離線閱讀中，外部地圖與即時資訊可能無法開啟。
+                    </div>
+                )}
+
+                {(beforeTrip || afterTrip) && selectedIndex === effectiveIndex && (
+                    <div className="flex items-start gap-3 rounded-2xl border border-[#bfd9df] bg-[#eaf5f7] p-4 text-sm text-[#285c6d]">
+                        <Info className="mt-0.5 size-5 shrink-0" />
+                        <p>
+                            {beforeTrip
+                                ? "旅程尚未開始，先顯示第一天，方便完成行前準備。"
+                                : "旅程已結束，保留最後一天作為旅行記錄。"}
+                        </p>
+                    </div>
+                )}
+
+                {manualSelection && (
+                    <Button
+                        onClick={returnToToday}
+                        className="h-11 w-full rounded-full bg-[#126b8a] font-bold text-white hover:bg-[#0e5973]"
+                    >
+                        <Navigation className="size-4" />
+                        回到目前旅程日
+                    </Button>
+                )}
+
+                <section aria-labelledby="selected-day-heading">
+                    <div className="flex items-end justify-between gap-4">
+                        <div>
+                            <p className="font-mono text-xs font-bold tracking-[0.14em] text-[#126b8a]">
+                                {day.date.replaceAll("-", ".")} · {day.weekday}
+                            </p>
+                            <h2
+                                id="selected-day-heading"
+                                className="mt-1 text-3xl font-black tracking-[-0.035em] text-[#17323b]"
+                            >
+                                {day.city}
+                            </h2>
+                        </div>
+                        <span className="font-mono text-4xl font-black text-[#c9dde2]">
+                            {day.dayLabel}
+                        </span>
+                    </div>
+                    <p className="mt-3 text-lg font-extrabold leading-snug text-[#294852]">
+                        {day.theme}
+                    </p>
+                    {day.note && (
+                        <p className="mt-2 border-l-4 border-[#f2c94c] pl-3 text-sm leading-6 text-[#607983]">
+                            {day.note}
+                        </p>
+                    )}
+                </section>
+
+                {day.cycling && <CyclingProgress cycling={day.cycling} />}
+                {selectedIndex < trip.preparationVisibleThroughDay && (
+                    <Checklist
+                        items={PREPARATION_ITEMS}
+                        storageKey={storageKey}
+                        title={trip.preparationTitle}
+                    />
+                )}
+
+                <section className="relative space-y-4 pl-8" aria-label={`${day.city} 行程時間線`}>
+                    <div
+                        aria-hidden="true"
+                        className="absolute bottom-5 left-[13px] top-5 w-[5px] rounded-full bg-[#126b8a]"
+                    />
+                    {day.events.map((event, index) => (
+                        <div key={event.id} className="relative">
+                            <span
+                                aria-hidden="true"
+                                className={cn(
+                                    "absolute -left-[27px] top-6 z-10 size-[15px] rounded-full border-[3px] border-[#f7faf8]",
+                                    index === 0 ? "bg-[#f2c94c]" : "bg-[#126b8a]",
+                                )}
+                            />
+                            <EventCard event={event} />
+                        </div>
+                    ))}
+                    <span
+                        aria-hidden="true"
+                        className="absolute -left-[1px] bottom-0 flex size-7 items-center justify-center rounded-full bg-[#17323b] text-white"
+                    >
+                        <Flag className="size-3.5" />
+                    </span>
+                </section>
+
+                {day.contingencies && (
+                    <details className="group overflow-hidden rounded-[1.5rem] border border-[#efc1bb] bg-[#fff8f6]">
+                        <summary className="flex min-h-14 cursor-pointer list-none items-center justify-between gap-3 p-4 font-extrabold text-[#7f342d] [&::-webkit-details-marker]:hidden">
+                            <span className="flex items-center gap-3">
+                                <span className="flex size-9 items-center justify-center rounded-full bg-[#ffe4df]">
+                                    <CloudRain className="size-4" />
+                                </span>
+                                雨天／體力備案
+                            </span>
+                            <ChevronDown className="size-5 transition-transform group-open:rotate-180" />
+                        </summary>
+                        <div className="space-y-3 border-t border-[#f0d4d0] p-4">
+                            {day.contingencies.map((item) => (
+                                <div key={item} className="flex gap-2 text-sm leading-6 text-[#714c47]">
+                                    <CircleHelp className="mt-1 size-4 shrink-0" />
+                                    <p>{item}</p>
+                                </div>
+                            ))}
+                        </div>
+                    </details>
+                )}
+
+                <nav className="grid grid-cols-2 gap-3" aria-label="前後日期">
+                    <Button
+                        variant="outline"
+                        disabled={selectedIndex === 0}
+                        onClick={() => selectDay(selectedIndex - 1)}
+                        className="h-12 rounded-2xl border-[#b8d1d8] bg-white font-bold text-[#294852]"
+                    >
+                        <ChevronLeft className="size-4" />
+                        前一天
+                    </Button>
+                    <Button
+                        variant="outline"
+                        disabled={selectedIndex === days.length - 1}
+                        onClick={() => selectDay(selectedIndex + 1)}
+                        className="h-12 rounded-2xl border-[#b8d1d8] bg-white font-bold text-[#294852]"
+                    >
+                        後一天
+                        <ChevronRight className="size-4" />
+                    </Button>
+                </nav>
+
+                <a
+                    href={trip.sourceUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex min-h-14 items-center justify-between rounded-2xl border border-[#d6e3e6] bg-white px-4 text-sm font-bold text-[#506a73] transition-colors hover:bg-[#f2f7f8]"
+                >
+                    <span className="flex items-center gap-3">
+                        <FileText className="size-5 text-[#126b8a]" />
+                        查看原始行程文件
+                    </span>
+                    <ExternalLink className="size-4" />
+                </a>
+
+                <p className="flex items-center justify-center gap-2 pb-2 text-center text-[11px] font-medium text-[#789098]">
+                    <Sun className="size-3.5" />
+                    安全優先。交通與營業資訊請於出發前再次確認。
+                </p>
+            </div>
+        </main>
+    );
+}

--- a/docs/mobile-travel-guide-prd.md
+++ b/docs/mobile-travel-guide-prd.md
@@ -1,0 +1,193 @@
+# Mobile Travel Guide Timeline PRD
+
+## Problem Statement
+
+目前 TravelSplit 的 Plan 頁面只提供 Google Docs、Google Sheets 等外部資源連結。旅行途中若要確認今天的行程、下一個目的地、住宿、交通、預約資訊或雨天備案，使用者必須離開 App 並在長篇文件中自行尋找當天段落。
+
+這趟旅程為 2026 年 6 月 25 日至 7 月 2 日，共八天，涵蓋岡山、倉敷、尾道、島波海道、今治、道後溫泉與松山。其中 6 月 28 日至 6 月 30 日包含三天自行車行程，途中可能因天氣、體力、住宿位置與交通狀況調整節奏。旅途中主要以手機操作，也可能遇到網路不穩、單手操作或不方便反覆查找文件的情境。
+
+使用者需要一份適合手機閱讀的旅遊書，以日期與時間線呈現行程。App 應根據目前日期自動定位到當天，並讓內容隨日期自然往後推進，同時保留手動查看其他日期、開啟地圖與查閱備案的能力。
+
+## Solution
+
+將現有 Plan 頁面改造成手機優先的旅遊書時間線：
+
+- 以 2026 年 6 月 25 日至 7 月 2 日的每日行程為主要結構。
+- 進入頁面時，根據日本當地日期自動定位到今天。
+- 日期改變或 App 再次回到前景時，自動將目前行程推進至新的一天。
+- 以垂直時間線呈現交通、景點、餐飲、住宿、任務與提醒。
+- 清楚區分必要行程、可選景點、預約資訊、待確認事項及雨天／體力備案。
+- 提供「回到今天」與日期導覽，讓使用者可查看其他日期。
+- 使用者手動瀏覽其他日期時，不立即強制跳回今天。
+- 讓地點、交通、住宿與官方資訊可直接開啟外部地圖或網站。
+- 延續現有 PWA 與離線快取能力，使已載入的行程在網路不穩時仍可閱讀。
+- 保留原始 Google Doc 作為外部參考資料。
+
+## User Stories
+
+1. As a traveler, I want the Plan page to open on today's itinerary, so that I can immediately see what I need during the trip.
+2. As a traveler, I want the app to use Japan local time when determining the current day, so that the itinerary does not change at the wrong time.
+3. As a traveler, I want the timeline to advance when the calendar date changes, so that the displayed itinerary stays current.
+4. As a traveler, I want the app to refresh the current day after returning from the background, so that an overnight-open app does not remain on yesterday.
+5. As a traveler, I want a visible Today marker, so that I can understand my position in the full trip.
+6. As a traveler, I want a quick Return to Today action, so that I can recover after browsing another date.
+7. As a traveler, I want to swipe or tap between trip dates, so that I can preview tomorrow or review previous days.
+8. As a traveler, I want manual date browsing to remain stable, so that the app does not unexpectedly pull me back to today.
+9. As a traveler, I want dates before the trip to default to the first day, so that I can use the app for pre-trip preparation.
+10. As a traveler, I want dates after the trip to default to the final day or trip summary, so that completed travel information remains accessible.
+11. As a traveler, I want each day to show its day number, date, weekday and city, so that I can orient myself quickly.
+12. As a traveler, I want each day to have a short theme or goal, so that I understand the intended pace.
+13. As a traveler, I want itinerary events ordered chronologically, so that I can follow the day from top to bottom.
+14. As a traveler, I want events without exact times to support morning, afternoon and evening periods, so that flexible plans are not shown with false precision.
+15. As a traveler, I want fixed-time events to stand out, so that I do not miss flights, bike pickup or return deadlines.
+16. As a traveler, I want transport segments to show origin and destination, so that transfers are easy to follow.
+17. As a traveler, I want transport entries to show the recommended departure window, so that I can preserve schedule buffers.
+18. As a traveler, I want flight details available in the timeline, so that I can verify airport and departure information.
+19. As a traveler, I want the Okayama Airport bus reminder available on the arrival and departure days, so that I can plan airport transfers.
+20. As a traveler, I want time-sensitive information marked as requiring reconfirmation, so that I do not rely on an outdated timetable.
+21. As a traveler, I want lodging details attached to each applicable day, so that I can find the correct hotel at night.
+22. As a traveler, I want confirmed and cancelled lodging clearly distinguished, so that I do not navigate to an obsolete booking.
+23. As a traveler, I want booking platform and payment status visible, so that I can handle check-in questions.
+24. As a traveler, I want sensitive reservation references hidden by default, so that they are not exposed during normal browsing.
+25. As a traveler, I want to reveal and copy a reservation reference when needed, so that I can present it during pickup or check-in.
+26. As a traveler, I want each place to offer an Open in Maps action, so that I can start navigation without retyping its name.
+27. As a traveler, I want official websites linked from relevant events, so that I can verify current operating information.
+28. As a traveler, I want optional attractions visually separated from required stops, so that I can simplify the day when needed.
+29. As a traveler, I want priority stops identified, so that I know what to preserve when time is limited.
+30. As a traveler, I want daily notes to explain the intended pace, so that I avoid overloading the itinerary.
+31. As a cyclist, I want cycling days visually distinct from city travel days, so that I can prepare for the day's demands.
+32. As a cyclist, I want each riding day to show the planned route, so that I understand the sequence of islands and bridges.
+33. As a cyclist, I want expected start and arrival windows shown, so that I can avoid riding after dark.
+34. As a cyclist, I want bike pickup and return tasks highlighted, so that I do not miss rental requirements.
+35. As a cyclist, I want equipment reminders available before the first riding day, so that I can prepare rain gear, sunscreen, water and power.
+36. As a cyclist, I want baggage delivery tasks shown on the correct day, so that I do not carry unnecessary luggage.
+37. As a cyclist, I want food and water supply warnings for remote lodging, so that I can buy supplies before arrival.
+38. As a cyclist, I want physically demanding optional detours labeled, so that I can make decisions based on remaining energy.
+39. As a cyclist, I want a daily safety reminder not to ride at night, so that schedule pressure does not override safety.
+40. As a cyclist, I want the three riding days presented as one connected journey, so that I can see overall progress from Onomichi to Imabari.
+41. As a traveler, I want rain alternatives attached to affected days, so that I can adjust without searching the source document.
+42. As a traveler, I want fatigue alternatives attached to riding days, so that I can shorten the route safely.
+43. As a traveler, I want alternative transport such as ferry, bus or early bike return visible, so that I understand the fallback options.
+44. As a traveler, I want backup plans collapsed by default, so that the main itinerary remains easy to scan.
+45. As a traveler, I want warnings to distinguish safety-critical issues from general suggestions, so that I can prioritize correctly.
+46. As a traveler, I want incomplete decisions marked as To Confirm, so that outstanding preparation work is visible.
+47. As a traveler, I want completed reservations marked as Confirmed, so that I can distinguish planning from execution.
+48. As a traveler, I want a preparation checklist for bike rental, luggage and equipment, so that I can complete tasks before departure.
+49. As a traveler, I want checklist progress stored on my device, so that completed items remain checked offline.
+50. As a traveler, I want the checklist to avoid modifying expense data, so that itinerary actions cannot corrupt accounting records.
+51. As a traveler, I want the timeline to remain readable with one hand on a phone, so that it works during transit and cycling stops.
+52. As a traveler, I want large touch targets, so that actions remain usable outdoors.
+53. As a traveler, I want important text to remain readable in bright light, so that the guide is practical outside.
+54. As a traveler, I want the current event and next event emphasized, so that I do not need to scan the full day.
+55. As a traveler, I want completed or past events visually de-emphasized, so that upcoming information receives attention.
+56. As a traveler, I want the page to preserve my reading position when I briefly open another app, so that I can continue where I left off.
+57. As a traveler, I want reduced-motion preferences respected, so that automatic scrolling does not cause discomfort.
+58. As a traveler using assistive technology, I want the timeline to use meaningful headings and labels, so that the itinerary is navigable with a screen reader.
+59. As a traveler, I want itinerary content available after it has been loaded once, so that weak mobile reception does not block access.
+60. As a traveler, I want a clear offline state, so that I know external links and live information may be unavailable.
+61. As a traveler, I want failed external links not to block the rest of the guide, so that static itinerary content remains usable.
+62. As a traveler, I want the original Google Doc linked as a reference, so that I can inspect details not yet represented in the app.
+63. As a traveler, I want the expense, summary and plan sections to share the same selected trip, so that I do not accidentally view mismatched data.
+64. As a traveler with multiple trips, I want each trip to have its own itinerary data, so that switching Google Sheets also switches the travel guide.
+65. As a trip editor, I want itinerary data to be structured rather than embedded in presentation markup, so that dates and events can be maintained safely.
+66. As a trip editor, I want each event to support title, type, time, location, notes and links, so that common itinerary information is consistently represented.
+67. As a trip editor, I want events to support optional and required priority, so that the UI can communicate what may be skipped.
+68. As a trip editor, I want events to support confirmation status, so that bookings and unresolved details can be represented accurately.
+69. As a trip editor, I want events to support alternate plans, so that weather and fatigue contingencies remain attached to the relevant schedule.
+70. As a trip editor, I want missing optional fields to render gracefully, so that flexible activities do not require invented data.
+71. As a trip editor, I want invalid dates and malformed links detected during development, so that itinerary errors are found before travel.
+72. As a traveler, I want the guide to load quickly on a mobile connection, so that checking the next step does not interrupt the trip.
+73. As a traveler, I want the app to avoid continuous background location tracking, so that battery life and privacy are preserved.
+74. As a traveler, I want date-based progression to work without granting location permission, so that the core guide remains dependable.
+75. As a traveler, I want the itinerary to remain useful after the trip, so that it can serve as a travel record.
+
+## Implementation Decisions
+
+- Extend the existing Plan route rather than introducing a separate application or navigation hierarchy.
+- Keep the existing bottom navigation and selected-trip flow.
+- Treat the itinerary as structured trip data, separate from expense records.
+- Introduce a trip itinerary model containing trip metadata, trip timezone, day entries and timeline events.
+- Use `Asia/Tokyo` as the authoritative timezone for this itinerary. Device timezone must not determine the active travel date.
+- Determine the effective day using the following rules:
+  - Before 2026-06-25, select D1.
+  - From 2026-06-25 through 2026-07-02, select the matching local date.
+  - After 2026-07-02, select D8 and indicate that the trip has ended.
+- Re-evaluate the effective date when the Plan page mounts, when the browser returns to the foreground and when the local date changes while the page remains open.
+- Automatic date progression selects the correct day but must respect active manual browsing. A user-selected historical or future day remains selected until the user chooses Return to Today, reopens the Plan page, or the manual-selection session expires through a clearly defined navigation event.
+- Initial automatic positioning should scroll the active day or active event into view. Automatic scrolling must use reduced motion when requested by the operating system.
+- Use a vertically scrolling timeline as the primary mobile layout.
+- Keep date navigation sticky within the Plan experience so that the current day remains visible during scrolling.
+- Represent event types including transport, activity, food, lodging, cycling, task, reminder and contingency.
+- Represent time as either an exact time, a time range or a flexible period such as morning, afternoon or evening.
+- Represent event priority as required, recommended or optional.
+- Represent planning status as confirmed, to-confirm, cancelled or informational.
+- Visually suppress cancelled reservations while preserving them when they explain a replaced booking.
+- Keep reservation references outside normal card summaries and reveal them only through an explicit action.
+- Store non-sensitive itinerary completion state locally. Do not store authentication credentials or private booking documents in this state.
+- Use normal external HTTPS links for official resources and map search links for destinations.
+- Continue exposing the original planning document under external resources.
+- Reuse the existing PWA shell and persisted query infrastructure where suitable, while ensuring the static itinerary can render without a successful expense fetch.
+- The first version will encode the supplied eight-day itinerary as app-owned structured data. A later version may load itinerary data from a dedicated Google Sheet tab or API.
+- The initial content will cover:
+  - D1: Arrival at Okayama and station-area lodging.
+  - D2: Kurashiki Bikan Historical Quarter day trip.
+  - D3: Okayama to Onomichi, luggage forwarding and bicycle preparation.
+  - D4: Onomichi to Setoda cycling.
+  - D5: Setoda to Hakatajima cycling.
+  - D6: Hakatajima/Oshima to Imabari, bicycle return and transfer to Dogo Onsen.
+  - D7: Dogo Onsen and Matsuyama, followed by return to Okayama.
+  - D8: Light Okayama morning and flight home.
+- The itinerary must preserve source-document warnings about weather, avoiding night riding, airport bus reconfirmation, lodging supply limitations and the July 1 Matsuyama-to-Okayama transfer.
+- Labels and primary itinerary content will use Traditional Chinese, matching the source plan and current user context.
+
+## Testing Decisions
+
+- Tests should verify observable user behavior rather than internal React state or component implementation.
+- The highest test boundary is the rendered Plan page with a controlled clock, trip timezone and itinerary fixture.
+- Add unit tests for the date-selection logic because timezone and trip-boundary errors could send the user to the wrong day.
+- Date tests must cover:
+  - Before-trip selection.
+  - Every date from 2026-06-25 through 2026-07-02.
+  - After-trip selection.
+  - A device in `Asia/Taipei` while the trip date is evaluated in `Asia/Tokyo`.
+  - The date transition at Japan midnight.
+- Add interaction tests verifying that the page initially positions to today.
+- Add interaction tests verifying that returning from the background refreshes a stale date.
+- Add interaction tests verifying that manual date selection is not immediately overridden.
+- Add interaction tests for Return to Today.
+- Add interaction tests for previous-day and next-day navigation at the trip boundaries.
+- Add rendering tests for exact-time events, flexible-period events, optional events, cancelled lodging, warnings and collapsed contingencies.
+- Add accessibility tests for heading order, active-day semantics, button labels, keyboard navigation and reduced-motion behavior.
+- Add tests verifying that external map and official-site links have valid destinations and safe external-link attributes.
+- Add offline behavior coverage verifying that previously available itinerary content renders without a network response.
+- Add schema validation tests to reject duplicate day dates, events outside the trip range, malformed URLs and unsupported statuses.
+- The repository currently has no automated test framework. Implementation should add the smallest compatible React testing setup and establish Plan-page behavior as the first reference pattern.
+- Manual mobile verification should cover a narrow phone viewport, sticky navigation, long-day scrolling, large text settings, offline mode and PWA standalone display.
+
+## Out of Scope
+
+- Live GPS tracking or turn-by-turn bicycle navigation.
+- Automatic detection of arrival at a location.
+- Continuous background location access.
+- Live weather integration.
+- Live train, ferry, bus or flight status.
+- Automatic rescheduling based on delays, weather or cycling speed.
+- Editing the itinerary from within the mobile app.
+- Collaborative itinerary editing.
+- Automatic synchronization from arbitrary Google Doc formatting.
+- Parsing the source Google Doc at runtime.
+- Storing passports, payment cards, QR codes or full booking documents.
+- Replacing dedicated map and navigation applications.
+- Budget forecasting beyond the existing expense features.
+- Public sharing of the itinerary without authentication.
+- Generalizing the first release into a full multi-user travel publishing platform.
+
+## Further Notes
+
+- Source itinerary: [Google Doc](https://docs.google.com/document/d/11DVuL-VuJ-lVM6jNDhGosmNbzv4EdSEdew1zfslHdLI/edit?usp=drivesdk)
+- Trip dates: 2026-06-25 through 2026-07-02.
+- Primary trip timezone: `Asia/Tokyo`.
+- The app currently uses Next.js App Router, TypeScript, Tailwind CSS, DaisyUI, React Context, TanStack Query and IndexedDB-backed persistence.
+- The existing Plan page is an external-resource list and is the intended entry point for this feature.
+- The source document contains private reservation and payment details. Implementation must review which fields are appropriate to ship to the client and avoid exposing unnecessary sensitive information.
+- Airport and transportation schedules may change. The travel guide should clearly identify information that must be rechecked close to departure rather than presenting it as guaranteed live data.

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = "tripsplit-pwa-v1";
+const CACHE_VERSION = "tripsplit-pwa-v2";
 const APP_SHELL_CACHE = `${CACHE_VERSION}-shell`;
 const RUNTIME_CACHE = `${CACHE_VERSION}-runtime`;
 
@@ -8,6 +8,7 @@ const shellUrls = [
     "index.html",
     "summary.html",
     "plan.html",
+    "2026-shimanami.html",
     "select-sheet.html",
     "offline.html",
 ].map((path) => new URL(path, scopeUrl).toString());

--- a/src/travel/date.ts
+++ b/src/travel/date.ts
@@ -1,0 +1,29 @@
+export function getDateInTimeZone(date: Date, timeZone: string) {
+    const parts = new Intl.DateTimeFormat("en-CA", {
+        timeZone,
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+    }).formatToParts(date);
+
+    const values = Object.fromEntries(
+        parts.filter((part) => part.type !== "literal").map((part) => [part.type, part.value]),
+    );
+
+    return `${values.year}-${values.month}-${values.day}`;
+}
+
+export function getEffectiveDayIndex<T extends { date: string }>(
+    days: readonly T[],
+    now: Date,
+    timeZone: string,
+) {
+    const currentDate = getDateInTimeZone(now, timeZone);
+    const exactIndex = days.findIndex((day) => day.date === currentDate);
+
+    if (exactIndex >= 0) {
+        return exactIndex;
+    }
+
+    return currentDate < days[0].date ? 0 : days.length - 1;
+}

--- a/src/travel/registry.ts
+++ b/src/travel/registry.ts
@@ -1,0 +1,51 @@
+import type {
+    TravelBookDefinition,
+    TravelResource,
+} from "./types";
+
+export const SHIMANAMI_TRAVEL_BOOK = {
+    id: "2026-shimanami",
+    path: "/2026-shimanami",
+    sourceDocumentIds: [
+        "11DVuL-VuJ-lVM6jNDhGosmNbzv4EdSEdew1zfslHdLI",
+    ],
+    title: "瀨戶內・島波海道",
+    eyebrow: "2026 TRAVEL BOOK",
+    dateRange: "6/25–7/2",
+    destinations: "岡山、尾道、今治、松山",
+    metadata: {
+        title: "瀨戶內・島波海道 2026 | TripSplit",
+        description: "岡山、尾道、島波海道、今治與松山的八日行動旅行手冊。",
+    },
+} satisfies TravelBookDefinition;
+
+export const TRAVEL_BOOKS: readonly TravelBookDefinition[] = [
+    SHIMANAMI_TRAVEL_BOOK,
+];
+
+export function resourceMatchesTravelBook(
+    resource: TravelResource,
+    travelBook: TravelBookDefinition,
+) {
+    if (!resource.url) {
+        return false;
+    }
+
+    return travelBook.sourceDocumentIds.some((documentId) =>
+        resource.url?.includes(`/document/d/${documentId}`),
+    );
+}
+
+export function getTravelBooksForResources(
+    resources: readonly TravelResource[],
+) {
+    return TRAVEL_BOOKS.filter((travelBook) =>
+        resources.some((resource) =>
+            resourceMatchesTravelBook(resource, travelBook),
+        ),
+    );
+}
+
+export function isPublicTravelBookPath(pathname: string) {
+    return TRAVEL_BOOKS.some((travelBook) => travelBook.path === pathname);
+}

--- a/src/travel/shimanami.ts
+++ b/src/travel/shimanami.ts
@@ -1,0 +1,586 @@
+import { SHIMANAMI_TRAVEL_BOOK } from "./registry";
+
+export type ShimanamiEventType =
+    | "transport"
+    | "activity"
+    | "food"
+    | "lodging"
+    | "cycling"
+    | "task"
+    | "reminder";
+
+export type ShimanamiStatus =
+    | "confirmed"
+    | "to-confirm"
+    | "cancelled"
+    | "informational";
+
+export interface ShimanamiLink {
+    label: string;
+    url: string;
+    kind: "map" | "official";
+}
+
+export interface ShimanamiEvent {
+    id: string;
+    time: string;
+    title: string;
+    type: ShimanamiEventType;
+    location?: string;
+    description?: string;
+    priority?: "required" | "recommended" | "optional";
+    status?: ShimanamiStatus;
+    links?: ShimanamiLink[];
+    warning?: string;
+}
+
+export interface ShimanamiDay {
+    id: string;
+    date: string;
+    dayLabel: string;
+    weekday: string;
+    city: string;
+    theme: string;
+    cycling?: {
+        label: string;
+        route: string;
+        distance: string;
+        rideWindow: string;
+        progress: number;
+        startLabel: string;
+        endLabel: string;
+    };
+    note?: string;
+    events: ShimanamiEvent[];
+    contingencies?: string[];
+}
+
+export interface ShimanamiTrip {
+    title: string;
+    year: string;
+    heroTitle: string;
+    heroAccent: string;
+    routeSummary: string;
+    timezone: string;
+    timezoneLabel: string;
+    startDate: string;
+    endDate: string;
+    sourceUrl: string;
+    preparationTitle: string;
+    preparationVisibleThroughDay: number;
+    days: ShimanamiDay[];
+}
+
+const map = (query: string) =>
+    `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(query)}`;
+
+export const SHIMANAMI_TRIP = {
+    title: "瀨戶內・島波海道",
+    year: "2026",
+    heroTitle: "瀨戶內",
+    heroAccent: "島波海道",
+    routeSummary: "岡山 → 尾道 → 今治 → 松山",
+    timezone: "Asia/Tokyo",
+    timezoneLabel: "JST · 日本時間",
+    startDate: "2026-06-25",
+    endDate: "2026-07-02",
+    sourceUrl:
+        `https://docs.google.com/document/d/${SHIMANAMI_TRAVEL_BOOK.sourceDocumentIds[0]}/edit?usp=drivesdk`,
+    preparationTitle: "騎行準備",
+    preparationVisibleThroughDay: 3,
+    days: [
+        {
+            id: "day-1",
+            date: "2026-06-25",
+            dayLabel: "D1",
+            weekday: "週四",
+            city: "岡山",
+            theme: "抵達、換氣，先把旅程安頓好",
+            note: "第一天不塞景點。保留入境與交通延誤的空間。",
+            events: [
+                {
+                    id: "d1-flight",
+                    time: "抵達後",
+                    title: "抵達岡山機場",
+                    type: "transport",
+                    priority: "required",
+                    status: "confirmed",
+                    location: "岡山桃太郎機場",
+                    description: "完成入境後先確認利木津巴士班次與乘車處。",
+                    warning: "機場巴士時刻可能調整，出發前請重新確認。",
+                    links: [
+                        { label: "開啟地圖", url: map("岡山桃太郎機場"), kind: "map" },
+                        {
+                            label: "機場交通",
+                            url: "https://www.okayama-airport.org/tw/access/bus",
+                            kind: "official",
+                        },
+                    ],
+                },
+                {
+                    id: "d1-bus",
+                    time: "傍晚",
+                    title: "機場巴士 → 岡山站",
+                    type: "transport",
+                    priority: "required",
+                    status: "to-confirm",
+                    description: "抵達車站後步行前往住宿，晚餐以車站周邊為主。",
+                },
+                {
+                    id: "d1-hotel",
+                    time: "晚上",
+                    title: "岡山站周邊住宿",
+                    type: "lodging",
+                    priority: "required",
+                    status: "confirmed",
+                    location: "岡山站",
+                    links: [{ label: "開啟地圖", url: map("岡山站"), kind: "map" }],
+                },
+            ],
+        },
+        {
+            id: "day-2",
+            date: "2026-06-26",
+            dayLabel: "D2",
+            weekday: "週五",
+            city: "倉敷",
+            theme: "沿著白壁與運河，慢慢走一日",
+            note: "以美觀地區為核心。若下雨，縮短戶外散步並增加室內停留。",
+            events: [
+                {
+                    id: "d2-train",
+                    time: "09:00 前後",
+                    title: "岡山 → 倉敷",
+                    type: "transport",
+                    priority: "required",
+                    status: "informational",
+                    description: "搭乘 JR，抵達後步行進入美觀地區。",
+                    links: [{ label: "開啟地圖", url: map("倉敷站"), kind: "map" }],
+                },
+                {
+                    id: "d2-bikan",
+                    time: "上午",
+                    title: "倉敷美觀地區",
+                    type: "activity",
+                    priority: "required",
+                    status: "informational",
+                    location: "倉敷川沿岸",
+                    links: [
+                        { label: "開啟地圖", url: map("倉敷美觀地區"), kind: "map" },
+                    ],
+                },
+                {
+                    id: "d2-museum",
+                    time: "下午",
+                    title: "大原美術館",
+                    type: "activity",
+                    priority: "recommended",
+                    status: "to-confirm",
+                    description: "視開館資訊與現場步調決定停留時間。",
+                    links: [
+                        { label: "開啟地圖", url: map("大原美術館"), kind: "map" },
+                        {
+                            label: "官方網站",
+                            url: "https://www.ohara.or.jp/",
+                            kind: "official",
+                        },
+                    ],
+                },
+                {
+                    id: "d2-return",
+                    time: "傍晚",
+                    title: "返回岡山",
+                    type: "transport",
+                    priority: "required",
+                    status: "informational",
+                },
+            ],
+            contingencies: [
+                "雨勢大時，以大原美術館與室內商店為主，取消長距離街區散步。",
+                "體力不足時提早返回岡山，保留隔日移動與單車準備的精神。",
+            ],
+        },
+        {
+            id: "day-3",
+            date: "2026-06-27",
+            dayLabel: "D3",
+            weekday: "週六",
+            city: "尾道",
+            theme: "把大行李送走，把單車旅程準備好",
+            note: "今日的核心是行李轉送、租車確認與裝備補給，不追求景點數量。",
+            events: [
+                {
+                    id: "d3-train",
+                    time: "上午",
+                    title: "岡山 → 尾道",
+                    type: "transport",
+                    priority: "required",
+                    status: "to-confirm",
+                    description: "預留轉車與找寄送櫃台的時間。",
+                    links: [{ label: "開啟地圖", url: map("尾道站"), kind: "map" }],
+                },
+                {
+                    id: "d3-luggage",
+                    time: "抵達後",
+                    title: "辦理大行李轉送",
+                    type: "task",
+                    priority: "required",
+                    status: "to-confirm",
+                    description: "確認送達今治或道後住宿的日期；三日騎行只帶隨身裝備。",
+                },
+                {
+                    id: "d3-bike",
+                    time: "下午",
+                    title: "確認租車與還車條件",
+                    type: "task",
+                    priority: "required",
+                    status: "confirmed",
+                    location: "尾道港周邊租車點",
+                    links: [
+                        {
+                            label: "開啟地圖",
+                            url: map("尾道港 單車租借"),
+                            kind: "map",
+                        },
+                    ],
+                },
+                {
+                    id: "d3-supplies",
+                    time: "傍晚前",
+                    title: "補齊三日騎行裝備",
+                    type: "reminder",
+                    priority: "required",
+                    status: "informational",
+                    description: "雨具、防曬、水、行動電源、簡單補給與隔日早餐。",
+                    warning: "今晚完成補給，避免隔天臨時找店延後出發。",
+                },
+                {
+                    id: "d3-walk",
+                    time: "有餘裕",
+                    title: "尾道本通與海岸散步",
+                    type: "activity",
+                    priority: "optional",
+                    status: "informational",
+                    links: [{ label: "開啟地圖", url: map("尾道本通商店街"), kind: "map" }],
+                },
+            ],
+        },
+        {
+            id: "day-4",
+            date: "2026-06-28",
+            dayLabel: "D4",
+            weekday: "週日",
+            city: "尾道 → 瀨戶田",
+            theme: "第一段藍線：跨過向島與因島",
+            cycling: {
+                label: "SHIMANAMI RIDE",
+                route: "尾道 → 向島 → 因島 → 生口島・瀨戶田",
+                distance: "約 35–40 km",
+                rideWindow: "08:00 出發 · 16:00 前抵達",
+                progress: 34,
+                startLabel: "尾道",
+                endLabel: "今治",
+            },
+            note: "第一天刻意保守配速，熟悉車況、橋面風勢與補水節奏。",
+            events: [
+                {
+                    id: "d4-ferry",
+                    time: "08:00",
+                    title: "尾道渡船 → 向島",
+                    type: "transport",
+                    priority: "required",
+                    status: "to-confirm",
+                    description: "過海後沿路面藍線開始騎行。",
+                    links: [{ label: "開啟地圖", url: map("尾道渡船 向島"), kind: "map" }],
+                },
+                {
+                    id: "d4-ride",
+                    time: "上午至下午",
+                    title: "向島、因島、生口島",
+                    type: "cycling",
+                    priority: "required",
+                    status: "informational",
+                    description: "每座橋前都有爬升，過橋後主動補水，不等口渴。",
+                    warning: "16:00 前結束騎行，不因趕行程進入夜騎。",
+                },
+                {
+                    id: "d4-temple",
+                    time: "體力許可",
+                    title: "耕三寺或島上短停",
+                    type: "activity",
+                    priority: "optional",
+                    status: "informational",
+                    description: "只在抵達時間充足時安排，不壓縮安全緩衝。",
+                    links: [{ label: "開啟地圖", url: map("耕三寺"), kind: "map" }],
+                },
+                {
+                    id: "d4-hotel",
+                    time: "16:00 前",
+                    title: "瀨戶田住宿 Check-in",
+                    type: "lodging",
+                    priority: "required",
+                    status: "confirmed",
+                    links: [{ label: "開啟地圖", url: map("瀨戶田港"), kind: "map" }],
+                },
+            ],
+            contingencies: [
+                "雨勢或強風不適合騎乘時，先向租車與住宿方確認取消、延後或替代交通。",
+                "體力落後時取消所有支線，沿主線直接前往瀨戶田。",
+                "若已無法在天黑前抵達，停止騎行並尋找渡船或計程車等安全替代。",
+            ],
+        },
+        {
+            id: "day-5",
+            date: "2026-06-29",
+            dayLabel: "D5",
+            weekday: "週一",
+            city: "瀨戶田 → 伯方島",
+            theme: "島與橋的正中央，留力比里程重要",
+            cycling: {
+                label: "SHIMANAMI RIDE",
+                route: "生口島 → 大三島 → 伯方島",
+                distance: "約 40–50 km",
+                rideWindow: "08:30 出發 · 16:30 前抵達",
+                progress: 67,
+                startLabel: "尾道",
+                endLabel: "今治",
+            },
+            note: "住宿周邊餐飲與商店有限，離開大三島主要聚落前完成晚餐與補給確認。",
+            events: [
+                {
+                    id: "d5-breakfast",
+                    time: "出發前",
+                    title: "早餐、飲水與胎壓確認",
+                    type: "task",
+                    priority: "required",
+                    status: "informational",
+                },
+                {
+                    id: "d5-ride",
+                    time: "08:30",
+                    title: "生口島 → 大三島",
+                    type: "cycling",
+                    priority: "required",
+                    status: "informational",
+                    description: "保持能對話的速度，上午先完成主要里程。",
+                    warning: "避免夜騎；下午提早判斷是否取消繞路。",
+                },
+                {
+                    id: "d5-shrine",
+                    time: "中午前後",
+                    title: "大山祇神社",
+                    type: "activity",
+                    priority: "recommended",
+                    status: "informational",
+                    links: [{ label: "開啟地圖", url: map("大山祇神社"), kind: "map" }],
+                },
+                {
+                    id: "d5-detour",
+                    time: "體力充足",
+                    title: "大三島支線",
+                    type: "cycling",
+                    priority: "optional",
+                    status: "informational",
+                    description: "支線會增加里程與爬升。只在天氣穩定且時間領先時考慮。",
+                },
+                {
+                    id: "d5-supplies",
+                    time: "15:00 前",
+                    title: "購買晚餐、早餐與飲水",
+                    type: "task",
+                    priority: "required",
+                    status: "informational",
+                    warning: "伯方島住宿周邊補給有限，抵達前完成採買。",
+                },
+                {
+                    id: "d5-hotel",
+                    time: "16:30 前",
+                    title: "伯方島住宿",
+                    type: "lodging",
+                    priority: "required",
+                    status: "confirmed",
+                    links: [{ label: "開啟地圖", url: map("伯方島"), kind: "map" }],
+                },
+            ],
+            contingencies: [
+                "疲勞時完全取消大三島支線，沿島波海道主線前進。",
+                "雨勢增強時在有商店的聚落先停留，確認後續交通再移動。",
+            ],
+        },
+        {
+            id: "day-6",
+            date: "2026-06-30",
+            dayLabel: "D6",
+            weekday: "週二",
+            city: "伯方島 → 今治 → 道後",
+            theme: "跨過來島海峽，完成藍線",
+            cycling: {
+                label: "SHIMANAMI RIDE",
+                route: "伯方島 → 大島 → 來島海峽大橋 → 今治",
+                distance: "約 40–45 km",
+                rideWindow: "08:00 出發 · 15:30 前還車",
+                progress: 100,
+                startLabel: "尾道",
+                endLabel: "今治",
+            },
+            note: "今天有還車與轉乘時限。景點一律讓位給安全抵達今治。",
+            events: [
+                {
+                    id: "d6-start",
+                    time: "08:00",
+                    title: "伯方島出發",
+                    type: "cycling",
+                    priority: "required",
+                    status: "informational",
+                    description: "預留大島爬坡與來島海峽大橋風勢造成的時間差。",
+                    warning: "最後一天也不夜騎；若進度落後，提早啟動替代方案。",
+                },
+                {
+                    id: "d6-bridge",
+                    time: "中午前後",
+                    title: "來島海峽大橋",
+                    type: "cycling",
+                    priority: "required",
+                    status: "informational",
+                    links: [{ label: "開啟地圖", url: map("來島海峽大橋"), kind: "map" }],
+                },
+                {
+                    id: "d6-return",
+                    time: "15:30 前",
+                    title: "今治還車",
+                    type: "task",
+                    priority: "required",
+                    status: "confirmed",
+                    location: "今治站周邊",
+                    links: [{ label: "開啟地圖", url: map("今治站"), kind: "map" }],
+                },
+                {
+                    id: "d6-transfer",
+                    time: "傍晚",
+                    title: "今治 → 松山・道後溫泉",
+                    type: "transport",
+                    priority: "required",
+                    status: "to-confirm",
+                    description: "依實際還車時間選擇 JR 或巴士，保留轉乘緩衝。",
+                },
+                {
+                    id: "d6-dogo",
+                    time: "晚上",
+                    title: "道後溫泉住宿",
+                    type: "lodging",
+                    priority: "required",
+                    status: "confirmed",
+                    links: [{ label: "開啟地圖", url: map("道後溫泉"), kind: "map" }],
+                },
+            ],
+            contingencies: [
+                "進度明顯落後時，詢問沿線巴士、渡船或提前還車的可行方式。",
+                "強風或豪雨時不要勉強通過長橋，先在安全地點聯絡租車方。",
+            ],
+        },
+        {
+            id: "day-7",
+            date: "2026-07-01",
+            dayLabel: "D7",
+            weekday: "週三",
+            city: "道後・松山 → 岡山",
+            theme: "溫泉城收尾，傍晚回到岡山",
+            note: "今天必須回到岡山過夜，松山市區行程要服從跨海移動時刻。",
+            events: [
+                {
+                    id: "d7-dogo",
+                    time: "上午",
+                    title: "道後溫泉街散步",
+                    type: "activity",
+                    priority: "recommended",
+                    status: "informational",
+                    links: [{ label: "開啟地圖", url: map("道後溫泉本館"), kind: "map" }],
+                },
+                {
+                    id: "d7-castle",
+                    time: "中午前後",
+                    title: "松山城",
+                    type: "activity",
+                    priority: "optional",
+                    status: "informational",
+                    description: "依天氣、腿部疲勞與轉乘時刻決定是否上山。",
+                    links: [{ label: "開啟地圖", url: map("松山城"), kind: "map" }],
+                },
+                {
+                    id: "d7-transfer",
+                    time: "下午",
+                    title: "松山 → 岡山",
+                    type: "transport",
+                    priority: "required",
+                    status: "to-confirm",
+                    description: "提早前往車站，依最新時刻搭乘前往岡山的列車。",
+                    warning: "7 月 1 日必須完成跨海移動；出發前重新確認班次與轉乘。",
+                },
+                {
+                    id: "d7-hotel",
+                    time: "晚上",
+                    title: "岡山最後一晚",
+                    type: "lodging",
+                    priority: "required",
+                    status: "confirmed",
+                    location: "岡山站周邊",
+                },
+            ],
+        },
+        {
+            id: "day-8",
+            date: "2026-07-02",
+            dayLabel: "D8",
+            weekday: "週四",
+            city: "岡山 → 回家",
+            theme: "輕鬆早晨，留足機場時間",
+            note: "最後一天不安排遠距離景點。以準時抵達機場為唯一硬行程。",
+            events: [
+                {
+                    id: "d8-morning",
+                    time: "上午",
+                    title: "岡山站周邊自由活動",
+                    type: "activity",
+                    priority: "optional",
+                    status: "informational",
+                    description: "早餐、採買與整理行李，避免離開車站太遠。",
+                },
+                {
+                    id: "d8-bus",
+                    time: "起飛前預留",
+                    title: "岡山站 → 岡山機場",
+                    type: "transport",
+                    priority: "required",
+                    status: "to-confirm",
+                    description: "依國際線報到時間倒推，提早搭乘利木津巴士。",
+                    warning: "機場巴士時刻可能調整，前一晚再次確認。",
+                    links: [
+                        {
+                            label: "機場交通",
+                            url: "https://www.okayama-airport.org/tw/access/bus",
+                            kind: "official",
+                        },
+                    ],
+                },
+                {
+                    id: "d8-flight",
+                    time: "依機票",
+                    title: "岡山機場起飛",
+                    type: "transport",
+                    priority: "required",
+                    status: "confirmed",
+                    location: "岡山桃太郎機場",
+                },
+            ],
+        },
+    ] satisfies ShimanamiDay[],
+} satisfies ShimanamiTrip;
+
+export const PREPARATION_ITEMS = [
+    { id: "rental", label: "確認租車、取車與今治還車條件" },
+    { id: "luggage", label: "確認大行李轉送日期與收件住宿" },
+    { id: "rain", label: "雨衣、防水袋與鞋套" },
+    { id: "sun", label: "防曬、帽套與太陽眼鏡" },
+    { id: "power", label: "行動電源、充電線與離線地圖" },
+    { id: "repair", label: "確認隨車工具、備胎與救援方式" },
+];

--- a/src/travel/types.ts
+++ b/src/travel/types.ts
@@ -1,0 +1,17 @@
+export interface TravelBookDefinition {
+    id: string;
+    path: `/${string}`;
+    sourceDocumentIds: string[];
+    title: string;
+    eyebrow: string;
+    dateRange: string;
+    destinations: string;
+    metadata: {
+        title: string;
+        description: string;
+    };
+}
+
+export interface TravelResource {
+    url?: string;
+}


### PR DESCRIPTION
## Summary

* Added a public mobile travel book at `/2026-shimanami`
* Added an eight-day Traditional Chinese itinerary covering Okayama, Onomichi, Shimanami Kaido, Imabari, Dogo Onsen, and Matsuyama.
* Added Japan-time day detection, sticky date navigation, cycling progress, contingencies, offline messaging, map links, and a locally persisted preparation checklist.
* Bypassed authentication and the standard app navigation shell for travel-book routes.
* Added the travel book to PWA offline caching.
* Added a reusable travel-book registry that:
    * Matches books to the active sheet’s source Google Doc.
    * Displays matching book cards on the Plan page.
    * Identifies public travel-book routes.
* Kept the Shimanami layout and itinerary types book-specific so future travel books can use independent designs.
* Added the mobile travel guide PRD.

## Verification

* TypeScript validation passes.
* Production build and static export pass.
* /2026-shimanami is generated as a static route