### PR TITLE
Feat: Add Shimanami highlight images

### DIFF
--- a/components/AppHeader.tsx
+++ b/components/AppHeader.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+import { cn } from "@/lib/utils";
+import type { User } from "@/src/types";
+
+interface AppHeaderProps {
+    user: User;
+    brandHref?: string;
+    onAccountClick?: () => void;
+    accountDisabledLabel?: string;
+    className?: string;
+}
+
+export function AppHeader({
+    user,
+    brandHref,
+    onAccountClick,
+    accountDisabledLabel,
+    className,
+}: AppHeaderProps) {
+    const [imageFailed, setImageFailed] = React.useState(false);
+    const accountDisabled = !onAccountClick;
+    const initials =
+        user.name
+            .trim()
+            .split(/\s+/)
+            .map((part) => part[0])
+            .join("")
+            .slice(0, 2)
+            .toUpperCase() || "?";
+
+    React.useEffect(() => {
+        setImageFailed(false);
+    }, [user.picture]);
+
+    const brand = <span className="text-xl font-bold text-primary">TripSplit</span>;
+
+    return (
+        <header
+            className={cn(
+                "sticky top-0 z-30 flex h-16 items-center justify-between border-b border-border bg-surface px-4 shadow-sm transition-colors",
+                className,
+            )}
+        >
+            {brandHref ? (
+                <Link
+                    href={brandHref}
+                    className="flex min-h-11 items-center rounded-lg pr-2 transition-colors hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+                    aria-label="返回 TripSplit 主頁"
+                >
+                    {brand}
+                </Link>
+            ) : (
+                <h1>{brand}</h1>
+            )}
+
+            <button
+                type="button"
+                onClick={onAccountClick}
+                disabled={accountDisabled}
+                aria-label={
+                    accountDisabled
+                        ? accountDisabledLabel ?? `${user.name} 的帳戶選單已停用`
+                        : `開啟 ${user.name} 的帳戶選單`
+                }
+                title={accountDisabled ? accountDisabledLabel : undefined}
+                className={cn(
+                    "relative flex size-9 items-center justify-center overflow-hidden rounded-full border border-border bg-primary/10 text-xs font-bold text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2",
+                    accountDisabled
+                        ? "cursor-not-allowed opacity-70"
+                        : "transition-transform hover:scale-105 active:scale-95",
+                )}
+            >
+                <span aria-hidden="true">{initials}</span>
+                {user.picture && !imageFailed && (
+                    <img
+                        src={user.picture}
+                        alt=""
+                        onError={() => setImageFailed(true)}
+                        className="absolute inset-0 size-full object-cover"
+                        width={36}
+                        height={36}
+                    />
+                )}
+            </button>
+        </header>
+    );
+}
+

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -7,6 +7,7 @@ import { PieChart, List, NotebookPen } from "lucide-react";
 import { useAuthState } from "../src/stores/AuthStore";
 import { useExpenses } from "../src/stores/ExpensesStore";
 import { useUI } from "../src/stores/UIStore";
+import { AppHeader } from "./AppHeader";
 import { SideDrawer } from "./SideDrawer";
 
 interface LayoutProps {
@@ -26,21 +27,7 @@ export const Layout: React.FC<LayoutProps> = ({ children }) => {
     return (
         <>
             <SideDrawer />
-            {/* Header */}
-            <div className="p-4 bg-surface shadow sticky top-0 z-10 flex justify-between items-center transition-colors border-b border-border">
-                <h1 className="text-xl font-bold text-primary">TripSplit</h1>
-                <div className="text-xs">
-                    <button onClick={openDrawer} className="focus:outline-none">
-                        <img
-                            src={user.picture}
-                            alt={user.name}
-                            className="w-8 h-8 rounded-full border border-border"
-                            width={32}
-                            height={32}
-                        />
-                    </button>
-                </div>
-            </div>
+            <AppHeader user={user} onAccountClick={openDrawer} />
 
             {/* Main Content Area */}
             <div className="layout-container max-w-2xl mx-auto min-h-[calc(100dvh-140px)] max-h-[calc(100dvh-140px)] overflow-auto">

--- a/components/travel-books/shimanami/ShimanamiTravelBook.tsx
+++ b/components/travel-books/shimanami/ShimanamiTravelBook.tsx
@@ -22,12 +22,15 @@ import {
     Route,
     ShieldAlert,
     ShoppingBag,
+    Share2,
     Sun,
     Utensils,
     WifiOff,
 } from "lucide-react";
+import { AppHeader } from "@/components/AppHeader";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { useAuthState } from "@/src/stores/AuthStore";
 import {
     getDateInTimeZone,
     getEffectiveDayIndex,
@@ -330,6 +333,8 @@ function Checklist({
 
 export function ShimanamiTravelBook() {
     const trip = SHIMANAMI_TRIP;
+    const { isAuthInitialized, isSignedIn, user } = useAuthState();
+    const showUserHeader = isAuthInitialized && isSignedIn && Boolean(user);
     const storageKey = `${SHIMANAMI_TRAVEL_BOOK.id}-preparation`;
     const days = trip.days;
     const [effectiveIndex, setEffectiveIndex] = React.useState(() =>
@@ -338,7 +343,9 @@ export function ShimanamiTravelBook() {
     const [selectedIndex, setSelectedIndex] = React.useState(effectiveIndex);
     const [manualSelection, setManualSelection] = React.useState(false);
     const [offline, setOffline] = React.useState(false);
+    const [shareStatus, setShareStatus] = React.useState("");
     const dateStripRef = React.useRef<HTMLDivElement>(null);
+    const shareStatusTimerRef = React.useRef<number | null>(null);
 
     const refreshEffectiveDay = React.useCallback(() => {
         const nextIndex = getEffectiveDayIndex(days, new Date(), trip.timezone);
@@ -377,6 +384,14 @@ export function ShimanamiTravelBook() {
             });
     }, [selectedIndex]);
 
+    React.useEffect(() => {
+        return () => {
+            if (shareStatusTimerRef.current) {
+                window.clearTimeout(shareStatusTimerRef.current);
+            }
+        };
+    }, []);
+
     const day = days[selectedIndex];
     const currentTripDate = getDateInTimeZone(new Date(), trip.timezone);
     const beforeTrip = currentTripDate < trip.startDate;
@@ -392,8 +407,76 @@ export function ShimanamiTravelBook() {
         setSelectedIndex(effectiveIndex);
     };
 
+    const showShareStatus = (message: string) => {
+        setShareStatus(message);
+        if (shareStatusTimerRef.current) {
+            window.clearTimeout(shareStatusTimerRef.current);
+        }
+        shareStatusTimerRef.current = window.setTimeout(() => {
+            setShareStatus("");
+        }, 2500);
+    };
+
+    const copyCurrentUrl = async () => {
+        const url = window.location.href;
+
+        if (navigator.clipboard?.writeText) {
+            await navigator.clipboard.writeText(url);
+            return;
+        }
+
+        const input = document.createElement("textarea");
+        input.value = url;
+        input.setAttribute("readonly", "");
+        input.style.position = "fixed";
+        input.style.opacity = "0";
+        document.body.appendChild(input);
+        input.select();
+        const copied = document.execCommand("copy");
+        input.remove();
+
+        if (!copied) {
+            throw new Error("Unable to copy URL");
+        }
+    };
+
+    const shareTravelBook = async () => {
+        try {
+            if (navigator.share) {
+                await navigator.share({
+                    title: SHIMANAMI_TRAVEL_BOOK.metadata.title,
+                    text: SHIMANAMI_TRAVEL_BOOK.metadata.description,
+                    url: window.location.href,
+                });
+                showShareStatus("分享選單已開啟");
+                return;
+            }
+
+            await copyCurrentUrl();
+            showShareStatus("連結已複製");
+        } catch (error) {
+            if (error instanceof DOMException && error.name === "AbortError") {
+                return;
+            }
+
+            try {
+                await copyCurrentUrl();
+                showShareStatus("連結已複製");
+            } catch {
+                showShareStatus("無法複製連結");
+            }
+        }
+    };
+
     return (
         <main lang="zh-Hant" className="min-h-full bg-[#f7faf8] text-[#17323b]">
+            {showUserHeader && user && (
+                <AppHeader
+                    user={user}
+                    brandHref="/"
+                    accountDisabledLabel="旅遊手冊中無法開啟帳戶選單"
+                />
+            )}
             <header className="relative overflow-hidden bg-[#126b8a] px-5 pb-7 pt-8 text-white">
                 <div
                     aria-hidden="true"
@@ -408,10 +491,32 @@ export function ShimanamiTravelBook() {
                         <p className="font-mono text-[11px] font-bold tracking-[0.18em] text-[#cce7ed]">
                             TRAVEL BOOK · {trip.year}
                         </p>
-                        <span className="rounded-full bg-white/12 px-3 py-1 font-mono text-[10px] font-bold">
-                            {trip.timezoneLabel}
-                        </span>
+                        <div className="flex items-center gap-2">
+                            <span className="rounded-full bg-white/12 px-3 py-1 font-mono text-[10px] font-bold">
+                                {trip.timezoneLabel}
+                            </span>
+                            <Button
+                                type="button"
+                                variant="ghost"
+                                size="icon"
+                                onClick={shareTravelBook}
+                                aria-label="分享旅遊手冊"
+                                title="分享旅遊手冊"
+                                className="size-9 rounded-full bg-white/12 text-white hover:bg-white/20 hover:text-white"
+                            >
+                                <Share2 className="size-4" />
+                            </Button>
+                        </div>
                     </div>
+                    <p
+                        aria-live="polite"
+                        className={cn(
+                            "absolute right-0 top-11 rounded-full bg-[#17323b] px-3 py-1.5 text-xs font-bold shadow-lg transition-opacity",
+                            shareStatus ? "opacity-100" : "pointer-events-none opacity-0",
+                        )}
+                    >
+                        {shareStatus}
+                    </p>
                     <h1 className="mt-5 max-w-sm text-[2.55rem] font-black leading-[0.98] tracking-[-0.05em]">
                         {trip.heroTitle}
                         <br />
@@ -424,7 +529,12 @@ export function ShimanamiTravelBook() {
                 </div>
             </header>
 
-            <div className="sticky top-0 z-20 border-b border-[#c8dce1] bg-[#f7faf8]/95 backdrop-blur-md">
+            <div
+                className={cn(
+                    "sticky z-20 border-b border-[#c8dce1] bg-[#f7faf8]/95 backdrop-blur-md",
+                    showUserHeader ? "top-16" : "top-0",
+                )}
+            >
                 <div
                     ref={dateStripRef}
                     className="mx-auto flex max-w-xl gap-2 overflow-x-auto px-4 py-3 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"

--- a/components/travel-books/shimanami/ShimanamiTravelBook.tsx
+++ b/components/travel-books/shimanami/ShimanamiTravelBook.tsx
@@ -122,6 +122,9 @@ function EventCard({ event }: { event: ShimanamiEvent }) {
                     {event.description && (
                         <p className="mt-2 text-sm leading-6 text-[#506a73]">{event.description}</p>
                     )}
+                    {event.highlight && (
+                        <HighlightImage highlight={event.highlight} />
+                    )}
                     {event.warning && (
                         <div className="mt-3 flex gap-2 rounded-xl bg-[#fff0ed] p-3 text-xs font-semibold leading-5 text-[#9b3f36]">
                             <AlertTriangle className="mt-0.5 size-4 shrink-0" />
@@ -152,6 +155,57 @@ function EventCard({ event }: { event: ShimanamiEvent }) {
                 </div>
             </div>
         </article>
+    );
+}
+
+function HighlightImage({
+    highlight,
+}: {
+    highlight: NonNullable<ShimanamiEvent["highlight"]>;
+}) {
+    const [failed, setFailed] = React.useState(false);
+    const showPlaceholder = !highlight.src || failed;
+
+    return (
+        <figure className="mt-3 overflow-hidden rounded-xl border border-[#d6e3e6] bg-[#eaf5f7]">
+            {showPlaceholder ? (
+                <div
+                    className="flex aspect-[16/9] flex-col items-center justify-center gap-2 bg-[linear-gradient(135deg,#d9eef3,#f7faf8)] px-5 text-center"
+                    role="img"
+                    aria-label={`${highlight.placeholderName}圖片預留位置`}
+                >
+                    <MapPin className="size-6 text-[#126b8a]" />
+                    <span className="text-sm font-extrabold text-[#294852]">
+                        {highlight.placeholderName}
+                    </span>
+                    <span className="text-[11px] font-medium text-[#607983]">
+                        圖片預留位置
+                    </span>
+                </div>
+            ) : (
+                <img
+                    src={highlight.src}
+                    alt={highlight.alt}
+                    loading="lazy"
+                    decoding="async"
+                    onError={() => setFailed(true)}
+                    className="aspect-[16/9] w-full object-cover"
+                />
+            )}
+            <figcaption className="flex items-center justify-between gap-3 px-3 py-2 text-[10px] font-medium text-[#607983]">
+                <span>旅程亮點 · {highlight.placeholderName}</span>
+                {highlight.sourceUrl && highlight.sourceLabel && (
+                    <a
+                        href={highlight.sourceUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="shrink-0 font-bold text-[#126b8a] hover:underline"
+                    >
+                        圖片來源：{highlight.sourceLabel}
+                    </a>
+                )}
+            </figcaption>
+        </figure>
     );
 }
 

--- a/src/travel/shimanami.ts
+++ b/src/travel/shimanami.ts
@@ -480,6 +480,7 @@ export const SHIMANAMI_TRIP = {
                     status: "informational",
                     links: [{ label: "開啟地圖", url: map("來島海峽大橋"), kind: "map" }],
                     highlight: {
+                        src: "https://www.honda.co.jp/content/dam/site/www/outdoor/cq_img/trip/shimanami/day3/img_day03_01.jpg",
                         alt: "騎乘自行車通過來島海峽大橋",
                         sourceUrl:
                             "https://www.honda.co.jp/outdoor/trip/shimanami/day3/day3-03.html",

--- a/src/travel/shimanami.ts
+++ b/src/travel/shimanami.ts
@@ -32,6 +32,13 @@ export interface ShimanamiEvent {
     status?: ShimanamiStatus;
     links?: ShimanamiLink[];
     warning?: string;
+    highlight?: {
+        src?: string;
+        alt: string;
+        sourceUrl?: string;
+        sourceLabel?: string;
+        placeholderName: string;
+    };
 }
 
 export interface ShimanamiDay {
@@ -168,6 +175,14 @@ export const SHIMANAMI_TRIP = {
                     links: [
                         { label: "開啟地圖", url: map("倉敷美觀地區"), kind: "map" },
                     ],
+                    highlight: {
+                        src: "https://www.kurashiki-tabi.jp/wp-content/uploads/2023/12/standard_01_top.jpg",
+                        alt: "倉敷美觀地區的白壁町家、運河與柳樹",
+                        sourceUrl:
+                            "https://www.kurashiki-tabi.jp/standard/kurashiki-bikan-historical-quarter/",
+                        sourceLabel: "倉敷觀光 WEB",
+                        placeholderName: "倉敷美觀地區運河",
+                    },
                 },
                 {
                     id: "d2-museum",
@@ -302,6 +317,13 @@ export const SHIMANAMI_TRIP = {
                     status: "informational",
                     description: "每座橋前都有爬升，過橋後主動補水，不等口渴。",
                     warning: "16:00 前結束騎行，不因趕行程進入夜騎。",
+                    highlight: {
+                        src: "https://www.japan-guide.com/g19/3478_12.jpg",
+                        alt: "島波海道自行車道沿著瀨戶內海跨越島嶼",
+                        sourceUrl: "https://www.japan-guide.com/e/e3478.html",
+                        sourceLabel: "Japan Guide",
+                        placeholderName: "島波海道跨海自行車道",
+                    },
                 },
                 {
                     id: "d4-temple",
@@ -321,6 +343,13 @@ export const SHIMANAMI_TRIP = {
                     priority: "required",
                     status: "confirmed",
                     links: [{ label: "開啟地圖", url: map("瀨戶田港"), kind: "map" }],
+                    highlight: {
+                        src: "https://san-tatsu.jp/assets/uploads/2023/06/20171423/22ba2e1cd7c0f61b12eacd0aba8c3281.jpg",
+                        alt: "生口島瀨戶田的檸檬自行車與跨海大橋景色",
+                        sourceUrl: "https://san-tatsu.jp/articles/246169/",
+                        sourceLabel: "散步的達人",
+                        placeholderName: "瀨戶田檸檬島",
+                    },
                 },
             ],
             contingencies: [
@@ -373,6 +402,13 @@ export const SHIMANAMI_TRIP = {
                     priority: "recommended",
                     status: "informational",
                     links: [{ label: "開啟地圖", url: map("大山祇神社"), kind: "map" }],
+                    highlight: {
+                        src: "https://oomishimagu.jp/wp/wp-content/uploads/2020/10/ogp-3.jpg",
+                        alt: "大三島大山祇神社的本殿與森林境內",
+                        sourceUrl: "https://oomishimagu.jp/",
+                        sourceLabel: "大山祇神社",
+                        placeholderName: "大山祇神社本殿",
+                    },
                 },
                 {
                     id: "d5-detour",
@@ -443,6 +479,13 @@ export const SHIMANAMI_TRIP = {
                     priority: "required",
                     status: "informational",
                     links: [{ label: "開啟地圖", url: map("來島海峽大橋"), kind: "map" }],
+                    highlight: {
+                        alt: "騎乘自行車通過來島海峽大橋",
+                        sourceUrl:
+                            "https://www.honda.co.jp/outdoor/trip/shimanami/day3/day3-03.html",
+                        sourceLabel: "Honda Outdoor",
+                        placeholderName: "來島海峽大橋騎行",
+                    },
                 },
                 {
                     id: "d6-return",
@@ -471,6 +514,13 @@ export const SHIMANAMI_TRIP = {
                     priority: "required",
                     status: "confirmed",
                     links: [{ label: "開啟地圖", url: map("道後溫泉"), kind: "map" }],
+                    highlight: {
+                        src: "https://dogo.jp/wp-content/uploads/2017/01/slide_01.jpg",
+                        alt: "道後溫泉本館的木造建築外觀",
+                        sourceUrl: "https://dogo.jp/en/honkan.php",
+                        sourceLabel: "道後溫泉官方網站",
+                        placeholderName: "道後溫泉本館",
+                    },
                 },
             ],
             contingencies: [


### PR DESCRIPTION
## Summary

  - Added a mobile-first Shimanami travel book at `/2026-shimanami`.
  - Added structured eight-day itinerary data covering Okayama, Onomichi, Shimanami Kaido, Imabari, Dogo Onsen, and Matsuyama.
  - Added Japan-time day selection, sticky date navigation, cycling progress, contingencies, warnings, map links, offline status, and a
    persisted preparation checklist.

  - Added travel highlights with image placeholders/source attribution.
  - Made the travel-book route public, without authentication checks or bottom navigation.
  - Added conditional discovery from the Plan page based on the active sheet’s source Google Doc.
  - Introduced a reusable travel-book registry, resource matching, cards, and shared itinerary types for future books.
  - Extracted a reusable AppHeader shared by the main layout and signed-in travel-book view.
  - Added travel-book URL sharing with clipboard fallback.
  - Added the travel-book route to the PWA cache.

  ## Verification

  - TypeScript validation passes.
  - Production build and static export pass.
  - /2026-shimanami is generated as a static route.