### PR TITLE
feat: add 2026 Hokkaido road trip book

### DIFF
--- a/app/2026-hokkaido-car/page.tsx
+++ b/app/2026-hokkaido-car/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+import { HokkaidoTravelBook } from "@/components/travel-books/hokkaido/HokkaidoTravelBook";
+import { HOKKAIDO_CAR_TRAVEL_BOOK } from "@/src/travel/registry";
+
+export const metadata: Metadata = {
+    title: HOKKAIDO_CAR_TRAVEL_BOOK.metadata.title,
+    description: HOKKAIDO_CAR_TRAVEL_BOOK.metadata.description,
+};
+
+export default function HokkaidoTravelBookPage() {
+    return <HokkaidoTravelBook />;
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -188,3 +188,33 @@
         @apply font-sans;
     }
 }
+
+@layer utilities {
+    .font-hokkaido-body {
+        font-family:
+            "Noto Sans TC",
+            "PingFang TC",
+            "Microsoft JhengHei",
+            system-ui,
+            sans-serif;
+    }
+
+    .font-hokkaido-display {
+        font-family:
+            "LXGW WenKai TC",
+            "Kaiti TC",
+            "DFKai-SB",
+            "Noto Sans TC",
+            serif;
+    }
+
+    .font-hokkaido-data {
+        font-family:
+            "IBM Plex Sans Condensed",
+            "Arial Narrow",
+            "Noto Sans TC",
+            system-ui,
+            sans-serif;
+        font-stretch: condensed;
+    }
+}

--- a/components/travel-books/TravelBookCard.tsx
+++ b/components/travel-books/TravelBookCard.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { ArrowRight, Bike } from "lucide-react";
+import { ArrowRight, Bike, CarFront } from "lucide-react";
 import type { TravelBookDefinition } from "@/src/travel/types";
 
 export function TravelBookCard({
@@ -7,15 +7,30 @@ export function TravelBookCard({
 }: {
     travelBook: TravelBookDefinition;
 }) {
+    const isRoadBook = travelBook.id === "2026-hokkaido-car";
+    const Icon = isRoadBook ? CarFront : Bike;
+
     return (
         <Link
             href={travelBook.path}
-            className="group relative block overflow-hidden rounded-[1.5rem] bg-[#126b8a] p-5 text-white shadow-lg transition-transform active:scale-[0.98]"
+            className={
+                isRoadBook
+                    ? "group relative block overflow-hidden rounded-[1.5rem] bg-[#172a36] p-5 text-white shadow-lg transition-transform active:scale-[0.98]"
+                    : "group relative block overflow-hidden rounded-[1.5rem] bg-[#126b8a] p-5 text-white shadow-lg transition-transform active:scale-[0.98]"
+            }
         >
             <div className="absolute -right-8 -top-10 size-36 rounded-full border-[18px] border-white/10" />
+            {isRoadBook && (
+                <div
+                    aria-hidden="true"
+                    className="absolute -bottom-14 right-12 h-40 w-20 rounded-t-full bg-black/15"
+                >
+                    <div className="mx-auto h-full w-0.5 bg-[repeating-linear-gradient(to_bottom,#f4c542_0,#f4c542_10px,transparent_10px,transparent_20px)]" />
+                </div>
+            )}
             <div className="relative">
                 <div className="flex items-center gap-2 text-xs font-bold tracking-[0.15em] text-[#f2c94c]">
-                    <Bike size={16} />
+                    <Icon size={16} />
                     {travelBook.eyebrow}
                 </div>
                 <h2 className="mt-4 text-2xl font-black tracking-tight">

--- a/components/travel-books/hokkaido/HokkaidoTravelBook.tsx
+++ b/components/travel-books/hokkaido/HokkaidoTravelBook.tsx
@@ -1,0 +1,1010 @@
+"use client";
+
+import * as React from "react";
+import useEmblaCarousel from "embla-carousel-react";
+import {
+    AlertTriangle,
+    BedDouble,
+    CarFront,
+    Check,
+    ChevronLeft,
+    ChevronRight,
+    Clock3,
+    ExternalLink,
+    FileText,
+    Flag,
+    Fuel,
+    Hotel,
+    Info,
+    Map,
+    MapPin,
+    Mountain,
+    Navigation,
+    PackageCheck,
+    Plane,
+    Route,
+    Sailboat,
+    Share2,
+    ShieldAlert,
+    Sparkles,
+    TrainFront,
+    Utensils,
+    WifiOff,
+} from "lucide-react";
+import { AppHeader } from "@/components/AppHeader";
+import { Button } from "@/components/ui/button";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogHeader,
+    DialogTitle,
+    DialogTrigger,
+} from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
+import { useAuthState } from "@/src/stores/AuthStore";
+import {
+    getDateInTimeZone,
+    getEffectiveDayIndex,
+} from "@/src/travel/date";
+import {
+    HOKKAIDO_PREPARATION_ITEMS,
+    HOKKAIDO_TRIP,
+    type HokkaidoDay,
+    type HokkaidoDrivingSegment,
+    type HokkaidoEvent,
+    type HokkaidoEventType,
+    type HokkaidoWarningSeverity,
+} from "@/src/travel/hokkaido";
+import { HOKKAIDO_CAR_TRAVEL_BOOK } from "@/src/travel/registry";
+
+const EVENT_ICON: Record<
+    HokkaidoEventType,
+    React.ComponentType<{ className?: string }>
+> = {
+    drive: CarFront,
+    ferry: Sailboat,
+    flight: Plane,
+    transit: TrainFront,
+    activity: Mountain,
+    food: Utensils,
+    lodging: Hotel,
+    task: Check,
+    reminder: Info,
+    safety: ShieldAlert,
+};
+
+const STATUS_LABEL = {
+    confirmed: "已確認",
+    "to-confirm": "待確認",
+    informational: "行程資訊",
+};
+
+const PRIORITY_LABEL = {
+    required: "必要",
+    recommended: "建議",
+    optional: "可選",
+};
+
+const WARNING_STYLE: Record<HokkaidoWarningSeverity, string> = {
+    notice: "border-[#d9cfea] bg-[#f3eff8] text-[#604d7e]",
+    deadline: "border-[#efd57a] bg-[#fff8d9] text-[#725800]",
+    safety: "border-[#efb4ac] bg-[#fff0ed] text-[#8b3931]",
+};
+
+function RoadRibbon({ driving }: { driving: HokkaidoDrivingSegment }) {
+    const routeStops = [
+        driving.origin,
+        ...driving.waypoints,
+        driving.destination,
+    ];
+    const isLongDrive = driving.distanceKm >= 200;
+    const isDriving = driving.mode === "driving";
+
+    return (
+        <section
+            className={cn(
+                "overflow-hidden rounded-[1.75rem] text-white shadow-[0_18px_45px_rgba(23,42,54,0.16)]",
+                isLongDrive ? "bg-[#172a36]" : "bg-[#176b87]",
+            )}
+            aria-label={`今日交通：${driving.origin}到${driving.destination}，${driving.distanceKm}公里`}
+        >
+            <div className="flex items-center justify-between gap-4 px-5 pb-3 pt-5">
+                <div>
+                    <p className="flex items-center gap-2 font-hokkaido-data text-[11px] font-bold uppercase tracking-[0.18em] text-white/65">
+                        <Route className="size-4 text-[#f4c542]" />
+                        Today&apos;s road
+                    </p>
+                    <p className="mt-1 text-sm font-bold text-white/90">
+                        {driving.mode === "parked"
+                            ? "車留港口 · 今日搭船"
+                            : driving.mode === "returned"
+                                ? "租車已歸還 · 公共交通"
+                                : isLongDrive
+                                    ? "長途移動日"
+                                    : "今日駕車"}
+                    </p>
+                </div>
+                <div className="text-right">
+                    <p className="font-hokkaido-data text-4xl font-bold leading-none tracking-[-0.04em] text-[#f4c542]">
+                        {driving.distanceKm}
+                    </p>
+                    <p className="font-hokkaido-data text-[10px] font-bold uppercase tracking-[0.2em] text-white/60">
+                        kilometers
+                    </p>
+                </div>
+            </div>
+
+            <div className="relative mx-5 overflow-hidden rounded-[1.25rem] bg-[#101f28] px-4 py-5">
+                <div
+                    aria-hidden="true"
+                    className="absolute bottom-0 left-1/2 top-0 w-[2px] -translate-x-1/2 bg-[repeating-linear-gradient(to_bottom,#f4c542_0,#f4c542_12px,transparent_12px,transparent_23px)] opacity-80"
+                />
+                <ol className="relative z-10 space-y-4">
+                    {routeStops.map((stop, index) => {
+                        const edge =
+                            index === 0 || index === routeStops.length - 1;
+                        const leftSide = index % 2 === 0;
+                        return (
+                            <li
+                                key={`${stop}-${index}`}
+                                className="grid grid-cols-[minmax(0,1fr)_24px_minmax(0,1fr)] items-center"
+                            >
+                                <div
+                                    className={cn(
+                                        "min-w-0 rounded-xl border px-3 py-2 text-xs font-bold leading-4",
+                                        edge
+                                            ? "border-[#f4c542]/55 bg-[#f4c542] text-[#172a36]"
+                                            : "border-white/15 bg-white/10 text-white",
+                                        leftSide
+                                            ? "col-start-1 mr-3 justify-self-end text-right"
+                                            : "col-start-3 ml-3 justify-self-start",
+                                    )}
+                                >
+                                    {stop}
+                                </div>
+                                <span
+                                    aria-hidden="true"
+                                    className={cn(
+                                        "col-start-2 row-start-1 mx-auto size-3 rounded-full border-2 border-[#101f28]",
+                                        edge ? "bg-[#f4c542]" : "bg-white",
+                                    )}
+                                />
+                            </li>
+                        );
+                    })}
+                </ol>
+            </div>
+
+            <div className="grid grid-cols-2 gap-px bg-white/10">
+                <div className="bg-black/10 px-5 py-4">
+                    <p className="font-hokkaido-data text-[10px] font-bold uppercase tracking-[0.16em] text-white/55">
+                        travel mode
+                    </p>
+                    <p className="mt-1 flex items-center gap-2 text-sm font-bold">
+                        {isDriving ? (
+                            <CarFront className="size-4 text-[#f4c542]" />
+                        ) : driving.mode === "parked" ? (
+                            <Sailboat className="size-4 text-[#f4c542]" />
+                        ) : (
+                            <TrainFront className="size-4 text-[#f4c542]" />
+                        )}
+                        {isDriving
+                            ? "自駕"
+                            : driving.mode === "parked"
+                                ? "渡輪"
+                                : "公共交通"}
+                    </p>
+                </div>
+                <div className="bg-black/10 px-5 py-4">
+                    <p className="font-hokkaido-data text-[10px] font-bold uppercase tracking-[0.16em] text-white/55">
+                        drive time
+                    </p>
+                    <p className="mt-1 flex items-center gap-2 text-sm font-bold">
+                        <Clock3 className="size-4 text-[#f4c542]" />
+                        {driving.duration || "不適用"}
+                    </p>
+                </div>
+            </div>
+
+            <div className="space-y-3 px-5 py-5">
+                <p className="text-sm leading-6 text-white/80">{driving.note}</p>
+                {driving.alerts?.map((alert) => (
+                    <div
+                        key={alert.label}
+                        className={cn(
+                            "flex gap-2 rounded-xl border px-3 py-2.5 text-xs font-bold leading-5",
+                            alert.severity === "safety" &&
+                                "border-[#d95d4f]/40 bg-[#d95d4f]/20 text-[#ffd9d3]",
+                            alert.severity === "deadline" &&
+                                "border-[#f4c542]/35 bg-[#f4c542]/15 text-[#ffe99b]",
+                            alert.severity === "notice" &&
+                                "border-white/15 bg-white/10 text-white/80",
+                        )}
+                    >
+                        {alert.severity === "safety" ? (
+                            <ShieldAlert className="mt-0.5 size-4 shrink-0" />
+                        ) : alert.severity === "deadline" ? (
+                            <Clock3 className="mt-0.5 size-4 shrink-0" />
+                        ) : (
+                            <Info className="mt-0.5 size-4 shrink-0" />
+                        )}
+                        <span>{alert.label}</span>
+                    </div>
+                ))}
+                {driving.mapUrl && (
+                    <Button
+                        asChild
+                        className="h-11 w-full rounded-full bg-[#f4c542] font-bold text-[#172a36] hover:bg-[#f8d562]"
+                    >
+                        <a
+                            href={driving.mapUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                        >
+                            <Navigation className="size-4" />
+                            開啟今日路線
+                        </a>
+                    </Button>
+                )}
+            </div>
+        </section>
+    );
+}
+
+function EventCard({ event }: { event: HokkaidoEvent }) {
+    const Icon = EVENT_ICON[event.type];
+    const optional = event.priority === "optional";
+
+    return (
+        <article
+            className={cn(
+                "rounded-[1.35rem] border bg-white p-4 shadow-[0_10px_28px_rgba(23,42,54,0.055)]",
+                optional
+                    ? "border-dashed border-[#b7a9ce] bg-[#fbf9fd]"
+                    : "border-[#d8e0e2]",
+            )}
+        >
+            <div className="flex items-start gap-3">
+                <div
+                    className={cn(
+                        "mt-0.5 flex size-10 shrink-0 items-center justify-center rounded-full",
+                        event.type === "safety"
+                            ? "bg-[#fff0ed] text-[#d95d4f]"
+                            : event.type === "lodging"
+                                ? "bg-[#f0ecf6] text-[#8067a8]"
+                                : "bg-[#e4f0f3] text-[#176b87]",
+                    )}
+                >
+                    <Icon className="size-[18px]" />
+                </div>
+                <div className="min-w-0 flex-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                        <span className="font-hokkaido-data text-xs font-bold tracking-wide text-[#176b87]">
+                            {event.time}
+                        </span>
+                        {event.priority && (
+                            <span
+                                className={cn(
+                                    "rounded-full px-2 py-0.5 text-[10px] font-bold",
+                                    event.priority === "required" &&
+                                        "bg-[#172a36] text-white",
+                                    event.priority === "recommended" &&
+                                        "bg-[#e4f0f3] text-[#14556b]",
+                                    event.priority === "optional" &&
+                                        "border border-[#b7a9ce] text-[#6c578e]",
+                                )}
+                            >
+                                {PRIORITY_LABEL[event.priority]}
+                            </span>
+                        )}
+                        {event.status && event.status !== "informational" && (
+                            <span
+                                className={cn(
+                                    "rounded-full px-2 py-0.5 text-[10px] font-bold",
+                                    event.status === "confirmed"
+                                        ? "bg-[#dff0e8] text-[#27664c]"
+                                        : "bg-[#fff4c7] text-[#725800]",
+                                )}
+                            >
+                                {STATUS_LABEL[event.status]}
+                            </span>
+                        )}
+                    </div>
+                    <h3 className="mt-1 text-[17px] font-black leading-snug text-[#172a36]">
+                        {event.title}
+                    </h3>
+                    {event.location && (
+                        <p className="mt-1 flex items-center gap-1 text-xs font-medium text-[#627780]">
+                            <MapPin className="size-3.5" />
+                            {event.location}
+                        </p>
+                    )}
+                    {event.description && (
+                        <p className="mt-2 text-sm leading-6 text-[#516872]">
+                            {event.description}
+                        </p>
+                    )}
+                    {event.lodging && (
+                        <div className="mt-3 rounded-xl border border-[#ded6e9] bg-[#f7f4fa] p-3">
+                            <p className="flex items-center gap-2 text-sm font-black text-[#4f3e69]">
+                                <BedDouble className="size-4" />
+                                {event.lodging.name}
+                            </p>
+                            {event.lodging.secondaryName && (
+                                <p className="mt-0.5 text-xs text-[#77698b]">
+                                    {event.lodging.secondaryName}
+                                </p>
+                            )}
+                            <div className="mt-2 flex flex-wrap gap-1.5">
+                                {event.lodging.nights && (
+                                    <span className="rounded-full bg-white px-2 py-1 text-[10px] font-bold text-[#5e5071]">
+                                        連住 {event.lodging.nights} 晚
+                                    </span>
+                                )}
+                                {event.lodging.meals && (
+                                    <span className="rounded-full bg-white px-2 py-1 text-[10px] font-bold text-[#5e5071]">
+                                        {event.lodging.meals}
+                                    </span>
+                                )}
+                                {event.lodging.platform && (
+                                    <span className="rounded-full bg-white px-2 py-1 text-[10px] font-bold text-[#5e5071]">
+                                        {event.lodging.platform}
+                                    </span>
+                                )}
+                                {event.lodging.payment && (
+                                    <span className="rounded-full bg-white px-2 py-1 text-[10px] font-bold text-[#5e5071]">
+                                        {event.lodging.payment}
+                                    </span>
+                                )}
+                            </div>
+                            <p className="mt-2 text-[10px] leading-4 text-[#857991]">
+                                訂房代碼與私人連結請查看原始文件。
+                            </p>
+                        </div>
+                    )}
+                    {event.warning && (
+                        <div
+                            className={cn(
+                                "mt-3 flex gap-2 rounded-xl border p-3 text-xs font-bold leading-5",
+                                WARNING_STYLE[
+                                    event.warningSeverity || "notice"
+                                ],
+                            )}
+                        >
+                            {event.warningSeverity === "safety" ? (
+                                <ShieldAlert className="mt-0.5 size-4 shrink-0" />
+                            ) : event.warningSeverity === "deadline" ? (
+                                <Clock3 className="mt-0.5 size-4 shrink-0" />
+                            ) : (
+                                <AlertTriangle className="mt-0.5 size-4 shrink-0" />
+                            )}
+                            <span>{event.warning}</span>
+                        </div>
+                    )}
+                    {event.links && (
+                        <div className="mt-3 flex flex-wrap gap-2">
+                            {event.links.map((link) => (
+                                <Button
+                                    key={link.url}
+                                    asChild
+                                    variant="outline"
+                                    className="h-10 rounded-full border-[#b9cdd2] bg-white px-3 text-xs font-bold text-[#176b87] hover:bg-[#edf5f6]"
+                                >
+                                    <a
+                                        href={link.url}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                    >
+                                        {link.kind === "map" ? (
+                                            <Navigation className="size-3.5" />
+                                        ) : (
+                                            <ExternalLink className="size-3.5" />
+                                        )}
+                                        {link.label}
+                                    </a>
+                                </Button>
+                            ))}
+                        </div>
+                    )}
+                </div>
+            </div>
+        </article>
+    );
+}
+
+function PreparationChecklist({ storageKey }: { storageKey: string }) {
+    const [checked, setChecked] = React.useState<string[]>([]);
+
+    React.useEffect(() => {
+        try {
+            setChecked(JSON.parse(localStorage.getItem(storageKey) || "[]"));
+        } catch {
+            setChecked([]);
+        }
+    }, [storageKey]);
+
+    const toggle = (id: string) => {
+        setChecked((current) => {
+            const next = current.includes(id)
+                ? current.filter((item) => item !== id)
+                : [...current, id];
+            localStorage.setItem(storageKey, JSON.stringify(next));
+            return next;
+        });
+    };
+
+    return (
+        <div className="p-5">
+            <div className="rounded-2xl bg-[#172a36] p-4 text-white">
+                <p className="font-hokkaido-data text-[10px] font-bold uppercase tracking-[0.18em] text-[#f4c542]">
+                    Before departure
+                </p>
+                <p className="mt-2 text-xl font-black">出發前要完成的事</p>
+                <p className="mt-1 text-sm leading-6 text-white/65">
+                    進度只儲存在這台裝置，不會改動原始文件或費用資料。
+                </p>
+            </div>
+            <div className="mt-4 space-y-2">
+                {HOKKAIDO_PREPARATION_ITEMS.map((item) => {
+                    const active = checked.includes(item.id);
+                    return (
+                        <label
+                            key={item.id}
+                            className="flex min-h-14 cursor-pointer items-center gap-3 rounded-2xl border border-[#d8e0e2] bg-white px-3 py-2 hover:bg-[#f4f8f8]"
+                        >
+                            <input
+                                type="checkbox"
+                                checked={active}
+                                onChange={() => toggle(item.id)}
+                                className="sr-only"
+                            />
+                            <span
+                                className={cn(
+                                    "flex size-7 shrink-0 items-center justify-center rounded-lg border-2",
+                                    active
+                                        ? "border-[#176b87] bg-[#176b87] text-white"
+                                        : "border-[#9db2b8] bg-white",
+                                )}
+                            >
+                                {active && (
+                                    <Check className="size-4" strokeWidth={3} />
+                                )}
+                            </span>
+                            <span
+                                className={cn(
+                                    "text-sm font-bold text-[#304852]",
+                                    active &&
+                                        "text-[#89999e] line-through",
+                                )}
+                            >
+                                {item.label}
+                            </span>
+                        </label>
+                    );
+                })}
+            </div>
+        </div>
+    );
+}
+
+function DayItinerary({ day }: { day: HokkaidoDay }) {
+    const headingId = `${day.id}-heading`;
+
+    return (
+        <div className="space-y-5">
+            <section aria-labelledby={headingId}>
+                <div className="flex items-start justify-between gap-4">
+                    <div>
+                        <p className="font-hokkaido-data text-xs font-bold uppercase tracking-[0.16em] text-[#176b87]">
+                            {day.date.replaceAll("-", ".")} · {day.weekday}
+                        </p>
+                        <p className="mt-2 text-xs font-bold text-[#8067a8]">
+                            {day.region}
+                        </p>
+                        <h2
+                            id={headingId}
+                            className="mt-1 text-[2rem] font-black leading-tight tracking-[-0.04em] text-[#172a36]"
+                        >
+                            {day.destination}
+                        </h2>
+                    </div>
+                    <span className="font-hokkaido-data text-5xl font-bold leading-none tracking-[-0.06em] text-[#cbd7da]">
+                        {day.dayLabel}
+                    </span>
+                </div>
+                <p className="mt-3 font-hokkaido-display text-xl font-bold leading-snug text-[#304852]">
+                    {day.theme}
+                </p>
+                {day.note && (
+                    <p className="mt-3 border-l-4 border-[#f4c542] pl-3 text-sm leading-6 text-[#627780]">
+                        {day.note}
+                    </p>
+                )}
+            </section>
+
+            <RoadRibbon driving={day.driving} />
+
+            <section
+                className="relative space-y-4 pl-8"
+                aria-label={`${day.destination} 行程時間線`}
+            >
+                <div
+                    aria-hidden="true"
+                    className="absolute bottom-6 left-[13px] top-5 w-[5px] rounded-full bg-[#176b87]"
+                />
+                {day.events.map((event, index) => (
+                    <div key={event.id} className="relative">
+                        <span
+                            aria-hidden="true"
+                            className={cn(
+                                "absolute -left-[27px] top-6 z-10 size-[15px] rounded-full border-[3px] border-[#f6f8f7]",
+                                event.warningSeverity === "safety"
+                                    ? "bg-[#d95d4f]"
+                                    : index === 0
+                                        ? "bg-[#f4c542]"
+                                        : event.type === "lodging"
+                                            ? "bg-[#8067a8]"
+                                            : "bg-[#176b87]",
+                            )}
+                        />
+                        <EventCard event={event} />
+                    </div>
+                ))}
+                <span
+                    aria-hidden="true"
+                    className="absolute -left-[1px] bottom-0 flex size-7 items-center justify-center rounded-full bg-[#172a36] text-white"
+                >
+                    <Flag className="size-3.5" />
+                </span>
+            </section>
+        </div>
+    );
+}
+
+export function HokkaidoTravelBook() {
+    const trip = HOKKAIDO_TRIP;
+    const days = trip.days;
+    const { isAuthInitialized, isSignedIn, user } = useAuthState();
+    const showUserHeader = isAuthInitialized && isSignedIn && Boolean(user);
+    const preparationStorageKey = `${HOKKAIDO_CAR_TRAVEL_BOOK.id}-preparation-v1`;
+    const [effectiveIndex, setEffectiveIndex] = React.useState(() =>
+        getEffectiveDayIndex(days, new Date(), trip.timezone),
+    );
+    const [selectedIndex, setSelectedIndex] = React.useState(effectiveIndex);
+    const [manualSelection, setManualSelection] = React.useState(false);
+    const [offline, setOffline] = React.useState(false);
+    const [shareStatus, setShareStatus] = React.useState("");
+    const [carouselHeight, setCarouselHeight] = React.useState<number>();
+    const [carouselRef, carouselApi] = useEmblaCarousel({
+        align: "start",
+        containScroll: "trimSnaps",
+        duration: 24,
+        startIndex: effectiveIndex,
+    });
+    const dateStripRef = React.useRef<HTMLDivElement>(null);
+    const shareStatusTimerRef = React.useRef<number | null>(null);
+
+    const refreshEffectiveDay = React.useCallback(() => {
+        const nextIndex = getEffectiveDayIndex(
+            days,
+            new Date(),
+            trip.timezone,
+        );
+        setEffectiveIndex(nextIndex);
+        if (!manualSelection) {
+            setSelectedIndex(nextIndex);
+        }
+    }, [days, manualSelection, trip.timezone]);
+
+    React.useEffect(() => {
+        const onVisibility = () => {
+            if (document.visibilityState === "visible") {
+                refreshEffectiveDay();
+            }
+        };
+        const onNetwork = () => setOffline(!navigator.onLine);
+        const timer = window.setInterval(refreshEffectiveDay, 60_000);
+
+        onNetwork();
+        document.addEventListener("visibilitychange", onVisibility);
+        window.addEventListener("online", onNetwork);
+        window.addEventListener("offline", onNetwork);
+
+        return () => {
+            window.clearInterval(timer);
+            document.removeEventListener("visibilitychange", onVisibility);
+            window.removeEventListener("online", onNetwork);
+            window.removeEventListener("offline", onNetwork);
+        };
+    }, [refreshEffectiveDay]);
+
+    React.useEffect(() => {
+        const reduceMotion = window.matchMedia(
+            "(prefers-reduced-motion: reduce)",
+        ).matches;
+        dateStripRef.current
+            ?.querySelector<HTMLElement>(
+                `[data-day-index="${selectedIndex}"]`,
+            )
+            ?.scrollIntoView({
+                behavior: reduceMotion ? "auto" : "smooth",
+                inline: "center",
+                block: "nearest",
+            });
+    }, [selectedIndex]);
+
+    React.useEffect(() => {
+        if (
+            !carouselApi ||
+            carouselApi.selectedScrollSnap() === selectedIndex
+        ) {
+            return;
+        }
+        carouselApi.scrollTo(selectedIndex);
+    }, [carouselApi, selectedIndex]);
+
+    React.useEffect(() => {
+        if (!carouselApi) {
+            return;
+        }
+
+        const onSelect = () => {
+            const nextIndex = carouselApi.selectedScrollSnap();
+            setSelectedIndex(nextIndex);
+            setManualSelection(nextIndex !== effectiveIndex);
+        };
+
+        carouselApi.on("select", onSelect);
+        carouselApi.on("reInit", onSelect);
+        return () => {
+            carouselApi.off("select", onSelect);
+            carouselApi.off("reInit", onSelect);
+        };
+    }, [carouselApi, effectiveIndex]);
+
+    React.useEffect(() => {
+        if (!carouselApi) {
+            return;
+        }
+
+        const slide = carouselApi.slideNodes()[selectedIndex];
+        if (!slide) {
+            return;
+        }
+
+        const updateHeight = () => setCarouselHeight(slide.scrollHeight);
+        updateHeight();
+        const observer = new ResizeObserver(updateHeight);
+        observer.observe(slide);
+        return () => observer.disconnect();
+    }, [carouselApi, selectedIndex]);
+
+    React.useEffect(
+        () => () => {
+            if (shareStatusTimerRef.current) {
+                window.clearTimeout(shareStatusTimerRef.current);
+            }
+        },
+        [],
+    );
+
+    const currentTripDate = getDateInTimeZone(new Date(), trip.timezone);
+    const beforeTrip = currentTripDate < trip.startDate;
+    const afterTrip = currentTripDate > trip.endDate;
+
+    const selectDay = (index: number) => {
+        setSelectedIndex(index);
+        setManualSelection(index !== effectiveIndex);
+    };
+
+    const returnToToday = () => {
+        setManualSelection(false);
+        setSelectedIndex(effectiveIndex);
+    };
+
+    const showShareStatus = (message: string) => {
+        setShareStatus(message);
+        if (shareStatusTimerRef.current) {
+            window.clearTimeout(shareStatusTimerRef.current);
+        }
+        shareStatusTimerRef.current = window.setTimeout(
+            () => setShareStatus(""),
+            2500,
+        );
+    };
+
+    const copyCurrentUrl = async () => {
+        if (navigator.clipboard?.writeText) {
+            await navigator.clipboard.writeText(window.location.href);
+            return;
+        }
+        throw new Error("Clipboard unavailable");
+    };
+
+    const shareTravelBook = async () => {
+        try {
+            if (navigator.share) {
+                await navigator.share({
+                    title: HOKKAIDO_CAR_TRAVEL_BOOK.metadata.title,
+                    text: HOKKAIDO_CAR_TRAVEL_BOOK.metadata.description,
+                    url: window.location.href,
+                });
+                return;
+            }
+            await copyCurrentUrl();
+            showShareStatus("連結已複製");
+        } catch (error) {
+            if (error instanceof DOMException && error.name === "AbortError") {
+                return;
+            }
+            showShareStatus("無法分享連結");
+        }
+    };
+
+    return (
+        <main
+            lang="zh-Hant"
+            className="min-h-full bg-[#f6f8f7] font-hokkaido-body text-[#172a36]"
+        >
+            {showUserHeader && user && (
+                <AppHeader
+                    user={user}
+                    brandHref="/"
+                    accountDisabledLabel="旅遊手冊中無法開啟帳戶選單"
+                />
+            )}
+
+            <header className="relative overflow-hidden bg-[#172a36] px-5 pb-8 pt-8 text-white">
+                <div
+                    aria-hidden="true"
+                    className="absolute inset-0 opacity-30 [background-image:linear-gradient(110deg,transparent_0%,transparent_46%,rgba(255,255,255,0.08)_46%,rgba(255,255,255,0.08)_47%,transparent_47%),radial-gradient(circle_at_82%_18%,#8067a8_0,transparent_24%)]"
+                />
+                <div
+                    aria-hidden="true"
+                    className="absolute -bottom-28 left-1/2 h-60 w-36 -translate-x-1/2 rounded-t-[4rem] bg-[#101f28]"
+                >
+                    <div className="mx-auto h-full w-[3px] bg-[repeating-linear-gradient(to_bottom,#f4c542_0,#f4c542_18px,transparent_18px,transparent_34px)]" />
+                </div>
+
+                <div className="relative mx-auto max-w-xl">
+                    <div className="flex items-center justify-between gap-3">
+                        <p className="font-hokkaido-data text-[11px] font-bold uppercase tracking-[0.2em] text-[#a9c8d2]">
+                            Hokkaido road book · {trip.year}
+                        </p>
+                        <div className="flex items-center gap-2">
+                            <span className="rounded-full bg-white/10 px-3 py-1 font-hokkaido-data text-[10px] font-bold">
+                                {trip.timezoneLabel}
+                            </span>
+                            <Dialog>
+                                <DialogTrigger asChild>
+                                    <Button
+                                        variant="ghost"
+                                        size="icon"
+                                        aria-label="開啟行前清單"
+                                        className="size-9 rounded-full bg-white/10 text-white hover:bg-white/20 hover:text-white"
+                                    >
+                                        <PackageCheck className="size-4" />
+                                    </Button>
+                                </DialogTrigger>
+                                <DialogContent className="max-h-[calc(100dvh-2rem)] gap-0 overflow-y-auto bg-[#f6f8f7] p-0 sm:max-w-xl">
+                                    <DialogHeader className="sr-only">
+                                        <DialogTitle>北海道行前清單</DialogTitle>
+                                        <DialogDescription>
+                                            管理渡輪、預約與裝備準備進度。
+                                        </DialogDescription>
+                                    </DialogHeader>
+                                    <PreparationChecklist
+                                        storageKey={preparationStorageKey}
+                                    />
+                                </DialogContent>
+                            </Dialog>
+                            <Button
+                                variant="ghost"
+                                size="icon"
+                                onClick={shareTravelBook}
+                                aria-label="分享北海道旅遊手冊"
+                                className="size-9 rounded-full bg-white/10 text-white hover:bg-white/20 hover:text-white"
+                            >
+                                <Share2 className="size-4" />
+                            </Button>
+                        </div>
+                    </div>
+
+                    <p
+                        aria-live="polite"
+                        className={cn(
+                            "absolute right-0 top-11 rounded-full bg-[#f4c542] px-3 py-1.5 text-xs font-bold text-[#172a36] shadow-lg transition-opacity",
+                            shareStatus
+                                ? "opacity-100"
+                                : "pointer-events-none opacity-0",
+                        )}
+                    >
+                        {shareStatus}
+                    </p>
+
+                    <div className="mt-10 max-w-md">
+                        <p className="flex items-center gap-2 text-xs font-bold text-[#c9dbe0]">
+                            <Sparkles className="size-4 text-[#f4c542]" />
+                            12 DAYS · 1,368 KM PLANNED
+                        </p>
+                        <h1 className="mt-3 font-hokkaido-display text-[3.2rem] font-bold leading-[0.94] tracking-[-0.055em]">
+                            {trip.heroTitle}
+                            <br />
+                            <span className="text-[#f4c542]">
+                                {trip.heroAccent}
+                            </span>
+                        </h1>
+                        <p className="mt-5 flex items-start gap-2 text-sm font-bold leading-6 text-[#c9dbe0]">
+                            <MapPin className="mt-1 size-4 shrink-0 text-[#8067a8]" />
+                            {trip.routeSummary}
+                        </p>
+                    </div>
+
+                    <div className="mt-7 grid grid-cols-2 gap-2">
+                        <div className="rounded-2xl border border-white/10 bg-white/5 p-3">
+                            <p className="font-hokkaido-data text-[9px] font-bold uppercase tracking-[0.18em] text-white/45">
+                                rental car
+                            </p>
+                            <p className="mt-1 text-xs font-bold">
+                                {trip.rentalPeriod}
+                            </p>
+                        </div>
+                        <div className="rounded-2xl border border-white/10 bg-white/5 p-3">
+                            <p className="font-hokkaido-data text-[9px] font-bold uppercase tracking-[0.18em] text-white/45">
+                                longest day
+                            </p>
+                            <p className="mt-1 text-xs font-bold">
+                                D8 · 220 km
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            </header>
+
+            <div
+                className={cn(
+                    "sticky z-20 border-b border-[#cad7da] bg-[#f6f8f7]/95 backdrop-blur-md",
+                    showUserHeader ? "top-16" : "top-0",
+                )}
+            >
+                <div
+                    ref={dateStripRef}
+                    className="mx-auto flex max-w-xl gap-2 overflow-x-auto px-4 py-3 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+                    aria-label="旅程日期"
+                >
+                    {days.map((day, index) => (
+                        <button
+                            key={day.id}
+                            type="button"
+                            data-day-index={index}
+                            onClick={() => selectDay(index)}
+                            aria-pressed={index === selectedIndex}
+                            className={cn(
+                                "relative min-w-[64px] rounded-2xl border px-3 py-2 text-center transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#176b87] focus-visible:ring-offset-2",
+                                index === selectedIndex
+                                    ? "border-[#172a36] bg-[#172a36] text-white"
+                                    : "border-[#d8e0e2] bg-white text-[#627780]",
+                            )}
+                        >
+                            <span className="block font-hokkaido-data text-[10px] font-bold">
+                                {day.dayLabel}
+                            </span>
+                            <span className="mt-0.5 block font-hokkaido-data text-sm font-bold">
+                                8/{Number(day.date.slice(8))}
+                            </span>
+                            {index === effectiveIndex && (
+                                <span
+                                    className="absolute -right-1 -top-1 size-3 rounded-full border-2 border-[#f6f8f7] bg-[#f4c542]"
+                                    aria-label="目前旅程日"
+                                />
+                            )}
+                        </button>
+                    ))}
+                </div>
+            </div>
+
+            <div className="mx-auto max-w-xl space-y-5 px-4 pb-12 pt-5">
+                {offline && (
+                    <div className="flex items-center gap-2 rounded-xl bg-[#fff4c7] px-3 py-2 text-xs font-bold text-[#725800]">
+                        <WifiOff className="size-4" />
+                        離線閱讀中，地圖與外部網站可能無法開啟。
+                    </div>
+                )}
+
+                {(beforeTrip || afterTrip) &&
+                    selectedIndex === effectiveIndex && (
+                        <div className="flex items-start gap-3 rounded-2xl border border-[#c5d8dd] bg-[#eaf3f5] p-4 text-sm leading-6 text-[#315d6b]">
+                            <Info className="mt-0.5 size-5 shrink-0" />
+                            <p>
+                                {beforeTrip
+                                    ? "旅程尚未開始，先顯示 D1，方便完成預約與裝備準備。"
+                                    : "旅程已結束，保留 D12 作為旅行記錄。"}
+                            </p>
+                        </div>
+                    )}
+
+                {manualSelection && (
+                    <Button
+                        onClick={returnToToday}
+                        className="h-11 w-full rounded-full bg-[#176b87] font-bold text-white hover:bg-[#145a72]"
+                    >
+                        <Navigation className="size-4" />
+                        回到目前旅程日
+                    </Button>
+                )}
+
+                <div
+                    ref={carouselRef}
+                    className="touch-pan-y overflow-hidden transition-[height] duration-300 ease-out motion-reduce:transition-none"
+                    style={{ height: carouselHeight }}
+                    role="region"
+                    aria-roledescription="carousel"
+                    aria-label="北海道每日行程"
+                >
+                    <div className="flex items-start">
+                        {days.map((day, index) => (
+                            <div
+                                key={day.id}
+                                className="min-w-0 flex-[0_0_100%]"
+                                role="group"
+                                aria-roledescription="slide"
+                                aria-label={`${index + 1} / ${days.length}`}
+                                aria-hidden={index !== selectedIndex}
+                                inert={index !== selectedIndex}
+                            >
+                                <DayItinerary day={day} />
+                            </div>
+                        ))}
+                    </div>
+                </div>
+
+                <nav className="grid grid-cols-2 gap-3" aria-label="前後日期">
+                    <Button
+                        variant="outline"
+                        disabled={selectedIndex === 0}
+                        onClick={() => selectDay(selectedIndex - 1)}
+                        className="h-12 rounded-2xl border-[#b9cdd2] bg-white font-bold text-[#304852]"
+                    >
+                        <ChevronLeft className="size-4" />
+                        前一天
+                    </Button>
+                    <Button
+                        variant="outline"
+                        disabled={selectedIndex === days.length - 1}
+                        onClick={() => selectDay(selectedIndex + 1)}
+                        className="h-12 rounded-2xl border-[#b9cdd2] bg-white font-bold text-[#304852]"
+                    >
+                        後一天
+                        <ChevronRight className="size-4" />
+                    </Button>
+                </nav>
+
+                <a
+                    href={trip.sourceUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex min-h-14 items-center justify-between rounded-2xl border border-[#d8e0e2] bg-white px-4 text-sm font-bold text-[#516872] transition-colors hover:bg-[#f0f5f5]"
+                >
+                    <span className="flex items-center gap-3">
+                        <FileText className="size-5 text-[#176b87]" />
+                        查看原始行程文件
+                    </span>
+                    <ExternalLink className="size-4" />
+                </a>
+
+                <div className="flex items-center justify-center gap-4 pb-2 text-[11px] font-bold text-[#819298]">
+                    <span className="flex items-center gap-1.5">
+                        <Fuel className="size-3.5" />
+                        半箱油就補滿
+                    </span>
+                    <span className="h-3 w-px bg-[#cbd5d8]" />
+                    <span className="flex items-center gap-1.5">
+                        <Map className="size-3.5" />
+                        時刻與路況再確認
+                    </span>
+                </div>
+            </div>
+        </main>
+    );
+}

--- a/docs/2026-hokkaido-car-prd.md
+++ b/docs/2026-hokkaido-car-prd.md
@@ -1,0 +1,215 @@
+# 2026 北海道自駕旅遊書 PRD
+
+## Problem Statement
+
+2026 年 8 月 5 日至 8 月 16 日的北海道旅程橫跨道北、道東、道央與札幌，共 12 天，其中 8 月 5 日至 8 月 14 日包含長距離自駕。現有行程集中在一份長篇 Google Doc，混合航班、租車、住宿、每日路線、景點、預約、付款狀態、參考文章與安全提醒。旅行途中若只想確認今天要去哪裡、要開多少公里、何時必須出發、沿途在哪裡休息或加油，必須反覆捲動並自行辨認當日段落。
+
+這趟旅程的執行風險主要來自每日移動距離、渡輪與景點截止時間、盆節車潮、道北與道東加油站稀疏，以及傍晚野生動物穿越道路。一般景點式時間線不足以表達自駕旅程的核心資訊；每日駕車路線、距離、預估時間、停靠點、還車期限與安全提醒必須比一般活動更醒目。
+
+使用者需要一個位於 `/2026-hokkaido-car`、適合手機與 PWA 使用的旅遊書 App。進入頁面時應自動顯示日本當地日期對應的行程，日期導覽必須支援水平滑動，並讓駕駛或同行者在戶外、單手操作與網路不穩的情境下快速取得下一段必要資訊。
+
+## Solution
+
+新增一個獨立的「2026 北海道自駕」公開旅遊書頁面，沿用 TravelSplit 現有旅遊書 registry、PWA shell、日期判斷與 Embla 滑動架構，將來源文件整理為 app-owned structured data。
+
+- 以 2026 年 8 月 5 日至 8 月 16 日的 12 天行程為主要內容。
+- 使用 `Asia/Tokyo` 判定當日，首次進入、跨日與 App 回到前景時自動定位。
+- 提供可水平滑動、可點選且固定於頁面上方的日期導覽。
+- 每日頁首先呈現「今日駕車」路線帶，包含起訖、途經點、距離、預估駕駛時間、道路性質與關鍵期限。
+- 在日程時間線中區分駕車、渡輪、航班、景點、餐飲、住宿、任務、提醒與安全警告。
+- 將加油、野生動物、末班接駁、最後入場、還車與塞車緩衝標成高優先資訊。
+- 提供地圖搜尋、官方網站與來源文件連結，但靜態行程在離線時仍可閱讀。
+- 以「北海道夏季公路圖鑑」建立專屬視覺，不直接複製島波海道旅遊書。
+- 使用 `Noto Sans TC` 作為主要閱讀字體、`IBM Plex Sans Condensed` 顯示時間與里程等道路資料、`LXGW WenKai TC` 少量用於旅程標題與章節引句。
+- 以貫穿每日內容的「公路路線帶」作為識別元素，讓駕車段落在快速掃視時優先被辨識。
+
+## User Stories
+
+1. As a traveler, I want `/2026-hokkaido-car` to open as a dedicated travel book, so that this trip is independent from expense and other trip content.
+2. As a traveler, I want the travel book to open on today's itinerary, so that I can immediately see the relevant plan.
+3. As a traveler, I want the app to use Japan local time, so that the active day changes at the correct time.
+4. As a traveler, I want dates before the trip to open on D1, so that I can use the guide for preparation.
+5. As a traveler, I want dates after the trip to open on D12, so that the guide remains useful as a record.
+6. As a traveler, I want the active day to refresh when the app returns from the background, so that an overnight-open app does not remain on yesterday.
+7. As a traveler, I want the active day to refresh when Japan's calendar date changes, so that the itinerary advances automatically.
+8. As a traveler, I want a visible today marker, so that I know where today sits in the full trip.
+9. As a traveler, I want a Return to Today action, so that I can recover after reviewing another date.
+10. As a traveler, I want manual date selection to remain stable, so that the app does not unexpectedly pull me away while planning.
+11. As a traveler, I want to swipe horizontally between dates, so that changing days feels natural on a phone.
+12. As a traveler, I want to tap a date in the sticky date strip, so that I can jump directly to any of the 12 days.
+13. As a traveler, I want previous and next controls to respect trip boundaries, so that I cannot navigate to an invalid day.
+14. As a keyboard user, I want the date strip and carousel to be operable without touch, so that the guide remains accessible.
+15. As a traveler, I want the selected date button to stay visible in the date strip, so that I do not lose orientation.
+16. As a traveler, I want each day to show D1–D12, date, weekday, destination and a short theme, so that I can identify the day quickly.
+17. As a traveler, I want today's driving route placed before the general timeline, so that the most safety-critical information appears first.
+18. As a driver, I want the route origin, destination and intermediate stops shown in sequence, so that I understand the day's shape.
+19. As a driver, I want the planned driving distance shown prominently, so that I can prepare for the day's workload.
+20. As a driver, I want an estimated driving duration shown when known, so that I can preserve realistic buffers.
+21. As a driver, I want non-driving days to explicitly show 0 km or no rental car, so that transport mode is unambiguous.
+22. As a driver, I want long-drive days visually distinguished, so that 200 km or greater days receive extra attention.
+23. As a driver, I want rest stops such as Sunagawa Highway Oasis attached to the relevant route, so that breaks are planned rather than improvised.
+24. As a driver, I want refueling reminders shown before remote areas, so that I do not pass a safe opportunity to refuel.
+25. As a driver, I want the half-tank rule visible on northern and eastern Hokkaido days, so that fuel planning stays conservative.
+26. As a driver, I want wildlife warnings emphasized for D5–D8, so that dusk driving risk is not treated as a general note.
+27. As a driver, I want recommended dusk speed guidance preserved from the source plan, so that I have an actionable safety rule.
+28. As a driver, I want the return-car deadline on D10 highlighted, so that the rental booking is not jeopardized.
+29. As a driver, I want the D10 route to include traffic, refueling and return buffers, so that the 13:30 deadline is realistic.
+30. As a traveler, I want ferry segments visually distinct from driving segments, so that parking the car at Wakkanai is clear.
+31. As a traveler, I want the Rishiri ferry schedule marked for reconfirmation, so that I do not depend on stale times.
+32. As a traveler, I want the first return ferry on D4 highlighted, so that the eastbound drive can start on time.
+33. As a traveler, I want flight numbers, departure times and airport deadlines available on D1 and D12, so that travel-day logistics are complete.
+34. As a traveler, I want car rental pickup details available on D1, so that I know when the road trip begins.
+35. As a traveler, I want car rental coverage dates visible in the trip overview, so that I know when the car is and is not available.
+36. As a traveler, I want each event ordered chronologically, so that I can follow the day from top to bottom.
+37. As a traveler, I want flexible events to use morning, afternoon or evening labels, so that the app does not invent false precision.
+38. As a traveler, I want fixed deadlines to stand out, so that I do not miss closing, entry, shuttle or departure times.
+39. As a traveler, I want required, recommended and optional stops distinguished, so that I know what to skip when delayed.
+40. As a traveler, I want confirmed, to-confirm and informational statuses distinguished, so that planning work remains visible.
+41. As a traveler, I want the Cape Soya certificate shop's 17:00 closing time highlighted on D2, so that I can arrive before closing.
+42. As a traveler, I want Abashiri Prison's final admission highlighted on D5, so that the stop is scheduled realistically.
+43. As a traveler, I want Shiretoko Five Lakes reservation requirements shown on D6, so that access is not assumed.
+44. As a traveler, I want the Kamuiwakka shuttle cutoff shown on D6, so that I do not miss the last service.
+45. As a traveler, I want the whale-watching decision marked as optional, so that it does not crowd out required Shiretoko activities.
+46. As a traveler, I want Lake Mashu's morning visibility advice shown on D7, so that the route reflects weather probability.
+47. As a traveler, I want the Blue Pond 16:00 light deadline shown on D8, so that the long drive has a clear arrival target.
+48. As a traveler, I want Farm Tomita's early arrival requirement highlighted on D9, so that Obon parking queues do not consume the day.
+49. As a traveler, I want Obon congestion warnings shown on D8–D10, so that I expect heavier traffic and parking demand.
+50. As a traveler, I want each lodging attached to the correct night, so that I navigate to the right destination after a long drive.
+51. As a traveler, I want multi-night stays clearly indicated, so that I know when luggage can remain at the hotel.
+52. As a traveler, I want breakfast and dinner inclusions visible, so that I can plan meals in remote areas.
+53. As a traveler, I want payment status and booking platform available without dominating the main card, so that check-in details remain accessible.
+54. As a traveler, I want booking IDs and other sensitive references hidden by default, so that normal browsing does not expose them.
+55. As a traveler, I want to reveal and copy a booking reference when needed, so that pickup and check-in are efficient.
+56. As a traveler, I want cancelled or superseded lodging suggestions visually suppressed, so that I do not navigate to an obsolete option.
+57. As a traveler, I want place cards to offer Open in Maps, so that I can start navigation without retyping Japanese names.
+58. As a traveler, I want routes to offer a multi-stop Google Maps action where practical, so that daily navigation setup is faster.
+59. As a traveler, I want official ferry, attraction and transport links attached to the relevant event, so that I can reconfirm live information.
+60. As a traveler, I want external links to open without interrupting the static guide, so that a failed website does not block the itinerary.
+61. As a traveler, I want the original Google Doc linked as a reference, so that I can inspect details not represented in the app.
+62. As a traveler, I want outstanding purchases and reservations available in a preparation checklist, so that unfinished work is visible before departure.
+63. As a traveler, I want ferry tickets, Rishiri scooter contact, hiking clothing, tripod and power equipment represented in preparation, so that the source document's tasks are preserved.
+64. As a traveler, I want checklist progress stored locally, so that completed preparation remains available offline.
+65. As a traveler, I want checklist state isolated by travel-book ID, so that it cannot collide with another trip.
+66. As a traveler, I want important static itinerary content available offline after the app is loaded, so that weak reception in remote Hokkaido does not block access.
+67. As a traveler, I want a visible offline indicator, so that I know maps and live websites may not work.
+68. As a traveler, I want the page to render without a successful expense API response, so that accounting availability does not affect the guide.
+69. As a traveler, I want large touch targets and strong contrast, so that the guide remains usable outdoors and in a moving vehicle by a passenger.
+70. As a traveler, I want key distance and time values to be scannable, so that I can understand the day's constraints at a glance.
+71. As a traveler, I want Traditional Chinese text optimized for mobile reading, so that long notes do not become tiring.
+72. As a traveler, I want Japanese and Latin place names to remain legible beside Chinese labels, so that I can match signs and booking records.
+73. As a traveler, I want a visual identity specific to Hokkaido roads, so that this book is not mistaken for the Shimanami cycling guide.
+74. As a traveler, I want reduced-motion preferences respected, so that carousel and auto-positioning motion does not cause discomfort.
+75. As a screen-reader user, I want meaningful headings, landmarks, active-day semantics and route descriptions, so that the guide is navigable non-visually.
+76. As a traveler, I want the current event and next deadline emphasized where time data permits, so that upcoming actions receive attention.
+77. As a traveler, I want past events visually de-emphasized without disappearing, so that the day's history remains available.
+78. As a traveler, I want the page to preserve reading position when briefly switching apps, so that checking maps does not reset the guide.
+79. As a trip editor, I want itinerary content stored as structured trip data, so that route facts can be maintained without editing presentation markup.
+80. As a trip editor, I want driving segments to support route stops, distance, duration, warnings and map links, so that self-drive information has a consistent schema.
+81. As a trip editor, I want events to support transport mode, time, title, place, status, priority, notes and links, so that all 12 days use one model.
+82. As a trip editor, I want lodging to support meal inclusion, booking platform, payment status and private references, so that check-in data is represented safely.
+83. As a trip editor, I want malformed dates, duplicate IDs, invalid links and out-of-range days rejected during development, so that content errors are found before travel.
+84. As a trip editor, I want the Hokkaido travel book registered by source document ID, so that it appears with the correct external resource.
+85. As a traveler, I want the travel book to be shareable by URL, so that companions can open the same itinerary.
+
+## Implementation Decisions
+
+- Add a public travel-book route at `/2026-hokkaido-car`.
+- Register the travel book under the existing trip registry using source document ID `1KTb3yvRp3MPHajXC5oqxgHQb6AjHNmERxbrX0KcEHmc`.
+- Reuse the existing public-route recognition and travel-book discovery behavior instead of introducing a separate application shell.
+- Keep itinerary data separate from expense records and encode the first release as app-owned structured TypeScript data.
+- Generalize reusable travel-book concepts where the existing Shimanami types are trip-specific. Shared concepts should include trip metadata, day, event, link, status, priority and current-day selection. Hokkaido-specific driving and lodging details may extend those shared concepts.
+- Define driving segments with origin, destination, ordered waypoints, distance in kilometers, optional estimated duration, route note, safety severity and map action.
+- Treat 200 km or more as a long-drive presentation state. This is a visual and content cue, not a live route calculation.
+- Use `Asia/Tokyo` as the authoritative timezone.
+- Select D1 before 2026-08-05, the matching day from 2026-08-05 through 2026-08-16, and D12 after 2026-08-16.
+- Re-evaluate the effective day on mount, on `visibilitychange` back to visible and at a lightweight interval sufficient to detect a Japan-date transition.
+- Preserve manual browsing until Return to Today, a fresh page entry or another explicitly defined reset. Background refresh must not immediately override a manually selected day.
+- Use the existing Embla carousel pattern for horizontal day swiping, synchronized with a sticky date strip and previous/next controls.
+- Keep every date directly selectable. The selected date must scroll into view in the date strip.
+- Respect `prefers-reduced-motion` for date-strip scrolling, carousel transitions and automatic positioning.
+- Place a dedicated driving summary before the general event timeline on D1–D10. D3 explicitly presents 0 km and parked-car/ferry mode. D11–D12 indicate that the rental car has been returned.
+- Initial daily driving data:
+  - D1: New Chitose Airport to Nayoro, 210 km, with Sunagawa Highway Oasis as a rest stop.
+  - D2: Nayoro to Wakkanai and Cape Soya, 180 km.
+  - D3: Wakkanai Port to Rishiri by ferry, 0 km by rental car.
+  - D4: Rishiri to Wakkanai by ferry, then Wakkanai to Mombetsu, 180 km.
+  - D5: Mombetsu to Abashiri Prison to Utoro, 160 km.
+  - D6: Shiretoko Five Lakes, sightseeing boat and Kamuiwakka area, 50 km.
+  - D7: Shiretoko to Lake Mashu to Lake Akan, 150 km.
+  - D8: Lake Akan via Obihiro and Blue Pond/Shirahige Falls to Biei, 220 km.
+  - D9: Farm Tomita, Shikisai-no-Oka and the Biei area, 60 km.
+  - D10: Biei to New Chitose Airport for the 13:30 return, 158 km and approximately 2.5 hours before buffers.
+  - D11: Sapporo city, no rental car.
+  - D12: Sapporo to New Chitose Airport by rail or other public transport, no rental car.
+- Represent event types including drive, ferry, flight, public transport, activity, food, lodging, task, reminder and safety.
+- Represent warning severity so that wildlife, fuel, hard deadlines and road safety are visually stronger than general advice.
+- Preserve source-document uncertainty. Suggestions and AI-generated planning notes must not be presented as confirmed reservations.
+- Show booking platform, payer/payment status and meal inclusion in lodging details, but hide booking references behind an explicit reveal action.
+- Do not ship unnecessary private information. Review source content before implementation and exclude personal identifiers or links that expose private booking sessions.
+- Generate map links from destination queries or explicit multi-stop directions. Do not embed a live map in the first version.
+- Keep the original source document available as an external reference.
+- Reuse local storage for non-sensitive preparation state and namespace keys by travel-book ID and schema version.
+- The Hokkaido visual system will use:
+  - Snowfield `#F6F8F7` for the page background.
+  - Okhotsk `#176B87` for primary navigation and route elements.
+  - Asphalt `#172A36` for primary text and road-data panels.
+  - Lavender `#8067A8` for scenic and regional accents.
+  - Road Yellow `#F4C542` for current-day markers and time-critical highlights.
+  - Safety Coral `#D95D4F` for safety-critical warnings.
+- Typography will use:
+  - `Noto Sans TC` for body text, controls and dense itinerary content.
+  - `IBM Plex Sans Condensed` for dates, times, distances, durations, day labels and utility data.
+  - `LXGW WenKai TC` only for the hero title and selected editorial phrases; it must not be used for safety instructions or dense body copy.
+- The signature component will be a road-route ribbon with a centerline, route nodes and distance labels. It must encode the real daily route rather than act as decoration.
+- Use a mobile-first single-column layout with a practical reading width. Desktop may add breathing room but should not turn the page into a dashboard.
+- Continue supporting PWA standalone display and offline access to static app assets and itinerary data.
+- Primary interface language will be Traditional Chinese. Japanese and English property names may be shown as secondary labels where useful for navigation and check-in.
+
+## Testing Decisions
+
+- Tests will verify observable user behavior rather than component internals or React state.
+- The highest test boundary will be the rendered `/2026-hokkaido-car` travel-book page with a controlled clock, controlled timezone and Hokkaido itinerary fixture.
+- Reuse the existing date-selection function as the unit-test boundary for trip-date behavior.
+- Add the smallest compatible React testing setup because the repository currently has no automated test framework.
+- Date tests will cover before-trip selection, every date from 2026-08-05 through 2026-08-16, after-trip selection, Japan midnight and a device configured to another timezone.
+- Page behavior tests will verify initial automatic selection, refresh after returning from background, manual-selection preservation and Return to Today.
+- Navigation tests will verify date-button selection, swipe selection, previous/next boundaries, date-strip synchronization and selected-date visibility.
+- Driving-card tests will verify route order, distance, duration, long-drive state, 0 km ferry day and no-car states after vehicle return.
+- Content tests will verify the hard constraints from the source: Cape Soya 17:00 close, Abashiri final admission, Shiretoko reservations, Kamuiwakka shuttle cutoff, Blue Pond 16:00 target, Farm Tomita early arrival and D10 13:30 car return.
+- Safety tests will verify that wildlife and refueling warnings render at stronger severity than general notes on the correct days.
+- Lodging tests will verify correct-night association, multi-night stays, meal inclusion, payment status and hidden reservation references.
+- Link tests will verify valid HTTPS destinations, safe external-link attributes and usable map-search or directions URLs.
+- Offline tests will verify that the static itinerary renders without expense API success and that offline status is visible.
+- Accessibility tests will verify heading order, route descriptions, active-day semantics, keyboard operation, focus visibility, minimum touch targets and reduced-motion behavior.
+- Typography and visual QA will be performed at narrow phone, standard phone and desktop widths, with additional checks for large text and bright-light contrast.
+- Manual browser verification should use the project's preferred Chrome plugin runtime when the feature is implemented.
+- The existing Shimanami travel book provides prior art for the registry, current-day logic, date strip, Embla carousel, timeline, external links, checklist persistence, sharing and offline indicator.
+
+## Out of Scope
+
+- Live GPS tracking, geofencing or automatic arrival detection.
+- Turn-by-turn navigation or replacing Google Maps.
+- Live traffic, road closure, weather, fuel-price, ferry, rail or flight-status integration.
+- Automatic route duration recalculation.
+- Background location permission or continuous battery-intensive tracking.
+- Runtime parsing or synchronization of arbitrary Google Doc formatting.
+- Editing itinerary content from within the app.
+- Collaborative itinerary editing.
+- Automatic rescheduling when a stop is delayed or skipped.
+- Uploading passports, licenses, payment cards, QR codes or full booking documents.
+- Public exposure of private booking references.
+- Expense forecasting or changes to existing split-expense behavior.
+- A generalized CMS for creating arbitrary travel books.
+- A desktop-first map dashboard.
+
+## Further Notes
+
+- Source itinerary: [2026 北海道自駕](https://docs.google.com/document/d/1KTb3yvRp3MPHajXC5oqxgHQb6AjHNmERxbrX0KcEHmc/edit?usp=drivesdk)
+- Trip dates: 2026-08-05 through 2026-08-16.
+- Rental-car period: 2026-08-05 13:30 through 2026-08-14 13:30.
+- Primary timezone: `Asia/Tokyo`.
+- The source document was last modified on 2026-05-23 when read for this PRD.
+- The repository uses Next.js App Router, TypeScript, Tailwind CSS, DaisyUI, React Context, TanStack Query, IndexedDB persistence and static export to GitHub Pages.
+- Some source-document statements are recommendations rather than confirmed bookings. Implementation must preserve that distinction.
+- External schedules and operating rules can change before August 2026. The app should identify what must be reconfirmed rather than implying live accuracy.
+- The selected fonts require a deliberate loading strategy. Body readability and offline reliability take priority; production should use framework-managed subsets or self-hosted assets where licensing permits, with CJK-capable system fallbacks.

--- a/src/travel/hokkaido.ts
+++ b/src/travel/hokkaido.ts
@@ -1,0 +1,1002 @@
+import { HOKKAIDO_CAR_TRAVEL_BOOK } from "./registry";
+
+export type HokkaidoEventType =
+    | "drive"
+    | "ferry"
+    | "flight"
+    | "transit"
+    | "activity"
+    | "food"
+    | "lodging"
+    | "task"
+    | "reminder"
+    | "safety";
+
+export type HokkaidoStatus =
+    | "confirmed"
+    | "to-confirm"
+    | "informational";
+
+export type HokkaidoPriority = "required" | "recommended" | "optional";
+
+export type HokkaidoWarningSeverity = "notice" | "deadline" | "safety";
+
+export interface HokkaidoLink {
+    label: string;
+    url: string;
+    kind: "map" | "official";
+}
+
+export interface HokkaidoLodging {
+    name: string;
+    secondaryName?: string;
+    nights?: number;
+    meals?: string;
+    platform?: string;
+    payment?: string;
+}
+
+export interface HokkaidoEvent {
+    id: string;
+    time: string;
+    title: string;
+    type: HokkaidoEventType;
+    location?: string;
+    description?: string;
+    priority?: HokkaidoPriority;
+    status?: HokkaidoStatus;
+    warning?: string;
+    warningSeverity?: HokkaidoWarningSeverity;
+    links?: HokkaidoLink[];
+    lodging?: HokkaidoLodging;
+}
+
+export interface HokkaidoDrivingSegment {
+    mode: "driving" | "parked" | "returned";
+    origin: string;
+    destination: string;
+    waypoints: string[];
+    distanceKm: number;
+    duration?: string;
+    note: string;
+    mapUrl?: string;
+    alerts?: {
+        label: string;
+        severity: HokkaidoWarningSeverity;
+    }[];
+}
+
+export interface HokkaidoDay {
+    id: string;
+    date: string;
+    dayLabel: string;
+    weekday: string;
+    region: string;
+    destination: string;
+    theme: string;
+    note?: string;
+    driving: HokkaidoDrivingSegment;
+    events: HokkaidoEvent[];
+}
+
+export interface HokkaidoTrip {
+    year: string;
+    title: string;
+    heroTitle: string;
+    heroAccent: string;
+    routeSummary: string;
+    timezone: string;
+    timezoneLabel: string;
+    startDate: string;
+    endDate: string;
+    rentalPeriod: string;
+    sourceUrl: string;
+    days: HokkaidoDay[];
+}
+
+const map = (query: string) =>
+    `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(query)}`;
+
+const directions = (
+    origin: string,
+    destination: string,
+    waypoints: string[] = [],
+) => {
+    const params = new URLSearchParams({
+        api: "1",
+        origin,
+        destination,
+        travelmode: "driving",
+    });
+
+    if (waypoints.length > 0) {
+        params.set("waypoints", waypoints.join("|"));
+    }
+
+    return `https://www.google.com/maps/dir/?${params.toString()}`;
+};
+
+export const HOKKAIDO_PREPARATION_ITEMS = [
+    { id: "rishiri-ferry", label: "確認並購買稚內 ↔ 利尻島船票" },
+    { id: "rishiri-scooter", label: "聯絡利尻島機車租借" },
+    { id: "shiretoko-lakes", label: "預約知床五湖講習／導覽" },
+    { id: "shiretoko-cruise", label: "確認知床觀光船或賞鯨行程" },
+    { id: "tripod", label: "準備相機腳架" },
+    { id: "power", label: "準備行動電源與車用充電線" },
+    { id: "hiking-shorts", label: "準備登山短褲" },
+    { id: "hiking-vest", label: "評估是否攜帶登山背心" },
+] as const;
+
+export const HOKKAIDO_TRIP: HokkaidoTrip = {
+    year: "2026",
+    title: "北海道自駕",
+    heroTitle: "北緯 45°",
+    heroAccent: "夏日公路",
+    routeSummary: "新千歲 → 宗谷岬 → 知床 → 阿寒湖 → 美瑛 → 札幌",
+    timezone: "Asia/Tokyo",
+    timezoneLabel: "JST · 日本時間",
+    startDate: "2026-08-05",
+    endDate: "2026-08-16",
+    rentalPeriod: "8/5 13:30 → 8/14 13:30",
+    sourceUrl:
+        `https://docs.google.com/document/d/${HOKKAIDO_CAR_TRAVEL_BOOK.sourceDocumentIds[0]}/edit?usp=drivesdk`,
+    days: [
+        {
+            id: "day-1",
+            date: "2026-08-05",
+            dayLabel: "D1",
+            weekday: "週三",
+            region: "道央 → 道北",
+            destination: "新千歲 → 名寄",
+            theme: "落地後一路向北，先完成第一段長移動",
+            note: "下機、午餐與取車都需要時間。第一天只安排道路休息，不塞額外景點。",
+            driving: {
+                mode: "driving",
+                origin: "新千歲機場",
+                destination: "名寄",
+                waypoints: ["砂川 Highway Oasis"],
+                distanceKm: 210,
+                duration: "約 3 小時",
+                note: "13:30 取車後出發；中途在砂川休息、補給與確認精神狀態。",
+                mapUrl: directions("新千歲機場", "HOTEL MYSTAYS Nayoro", [
+                    "砂川 Highway Oasis",
+                ]),
+                alerts: [
+                    { label: "第一天長途移動，疲勞時立即增加休息", severity: "safety" },
+                ],
+            },
+            events: [
+                {
+                    id: "d1-flight",
+                    time: "06:20–11:05",
+                    title: "IT234 台北 → 新千歲",
+                    type: "flight",
+                    priority: "required",
+                    status: "confirmed",
+                    location: "新千歲機場",
+                    description: "抵達後先用餐，再前往租車櫃台。",
+                    links: [{ label: "機場地圖", url: map("新千歲機場"), kind: "map" }],
+                },
+                {
+                    id: "d1-car",
+                    time: "13:30",
+                    title: "取車，開始北海道公路段",
+                    type: "task",
+                    priority: "required",
+                    status: "confirmed",
+                    description: "確認車況、油種、ETC、還車地點與 8/14 13:30 截止時間。",
+                    warning: "訂單代碼未放入公開頁面，需要時請查看原始文件。",
+                    warningSeverity: "notice",
+                },
+                {
+                    id: "d1-sunagawa",
+                    time: "途中",
+                    title: "砂川 Highway Oasis 休息",
+                    type: "drive",
+                    priority: "recommended",
+                    status: "informational",
+                    description: "大型休息站，可補充甜點、伴手禮與駕駛體力。",
+                    links: [{ label: "開啟地圖", url: map("砂川 Highway Oasis"), kind: "map" }],
+                },
+                {
+                    id: "d1-hotel",
+                    time: "晚上",
+                    title: "名寄住宿",
+                    type: "lodging",
+                    priority: "required",
+                    status: "confirmed",
+                    links: [{ label: "開啟地圖", url: map("HOTEL MYSTAYS Nayoro"), kind: "map" }],
+                    lodging: {
+                        name: "HOTEL MYSTAYS 名寄",
+                        secondaryName: "HOTEL MYSTAYS Nayoro",
+                        meals: "含早餐",
+                        platform: "Agoda",
+                        payment: "已付款",
+                    },
+                },
+            ],
+        },
+        {
+            id: "day-2",
+            date: "2026-08-06",
+            dayLabel: "D2",
+            weekday: "週四",
+            region: "道北",
+            destination: "名寄 → 宗谷岬 → 稚內",
+            theme: "沿著最北公路，抵達日本極北點",
+            driving: {
+                mode: "driving",
+                origin: "名寄",
+                destination: "稚內",
+                waypoints: ["宗谷岬"],
+                distanceKm: 180,
+                duration: "約 3 小時 15 分",
+                note: "下午先去宗谷岬，再回稚內住宿。沿途加油站間距開始拉長。",
+                mapUrl: directions("HOTEL MYSTAYS Nayoro", "Surfeel Hotel Wakkanai", [
+                    "宗谷岬",
+                ]),
+                alerts: [
+                    { label: "柏屋 17:00 關門，證明書需在此之前領取", severity: "deadline" },
+                    { label: "油量接近 1/2 就找連鎖加油站補滿", severity: "safety" },
+                ],
+            },
+            events: [
+                {
+                    id: "d2-drive",
+                    time: "上午",
+                    title: "名寄出發，沿道北前往宗谷",
+                    type: "drive",
+                    priority: "required",
+                    status: "informational",
+                },
+                {
+                    id: "d2-cape",
+                    time: "17:00 前",
+                    title: "宗谷岬與極北點證明書",
+                    type: "activity",
+                    priority: "required",
+                    status: "informational",
+                    location: "宗谷岬・柏屋",
+                    warning: "柏屋 17:00 關門，延誤時優先保留證明書與極北點。",
+                    warningSeverity: "deadline",
+                    links: [{ label: "開啟地圖", url: map("宗谷岬 柏屋"), kind: "map" }],
+                },
+                {
+                    id: "d2-hotel",
+                    time: "晚上",
+                    title: "稚內住宿",
+                    type: "lodging",
+                    priority: "required",
+                    status: "confirmed",
+                    links: [{ label: "開啟地圖", url: map("Surfeel Hotel Wakkanai"), kind: "map" }],
+                    lodging: {
+                        name: "稚內斯菲爾飯店",
+                        secondaryName: "Surfeel Hotel Wakkanai",
+                        meals: "含早餐",
+                        platform: "Agoda",
+                    },
+                },
+            ],
+        },
+        {
+            id: "day-3",
+            date: "2026-08-07",
+            dayLabel: "D3",
+            weekday: "週五",
+            region: "利尻島",
+            destination: "稚內 → 利尻島",
+            theme: "把車留在港口，換成海風與島上機車",
+            driving: {
+                mode: "parked",
+                origin: "稚內港",
+                destination: "利尻島",
+                waypoints: ["鴛泊港"],
+                distanceKm: 0,
+                note: "租車停在稚內港；搭 Heartland Ferry 上島，島上以租機車移動。",
+                alerts: [
+                    { label: "旺季船班與機車租借都要事前確認", severity: "deadline" },
+                ],
+            },
+            events: [
+                {
+                    id: "d3-parking",
+                    time: "早上",
+                    title: "稚內港停車",
+                    type: "task",
+                    priority: "required",
+                    status: "to-confirm",
+                    description: "確認過夜停車區與繳費方式，只帶島上過夜行李。",
+                    links: [{ label: "港口地圖", url: map("稚內港 Heartland Ferry"), kind: "map" }],
+                },
+                {
+                    id: "d3-ferry",
+                    time: "船班待確認",
+                    title: "Heartland Ferry → 利尻島",
+                    type: "ferry",
+                    priority: "required",
+                    status: "to-confirm",
+                    warning: "8 月旺季請在出發前重新確認時刻與報到時間。",
+                    warningSeverity: "deadline",
+                    links: [
+                        {
+                            label: "官方船班",
+                            url: "https://heartlandferry.jp/english/",
+                            kind: "official",
+                        },
+                    ],
+                },
+                {
+                    id: "d3-island",
+                    time: "抵達後",
+                    title: "租機車環島，看利尻富士",
+                    type: "activity",
+                    priority: "recommended",
+                    status: "to-confirm",
+                    description: "以鴛泊周邊、姬沼與利尻山景觀為主，依天候調整。",
+                    links: [{ label: "開啟地圖", url: map("利尻島 鴛泊港"), kind: "map" }],
+                },
+                {
+                    id: "d3-hotel",
+                    time: "晚上",
+                    title: "利尻島住宿",
+                    type: "lodging",
+                    priority: "required",
+                    status: "confirmed",
+                    lodging: {
+                        name: "旅館 雪國",
+                        secondaryName: "Ryokan Yukiguni",
+                        meals: "含早晚餐",
+                        platform: "Jalan",
+                    },
+                    links: [{ label: "開啟地圖", url: map("Ryokan Yukiguni Rishiri"), kind: "map" }],
+                },
+            ],
+        },
+        {
+            id: "day-4",
+            date: "2026-08-08",
+            dayLabel: "D4",
+            weekday: "週六",
+            region: "道北 → 鄂霍次克",
+            destination: "利尻 → 稚內 → 紋別",
+            theme: "清晨離島，沿著鄂霍次克海一路向東",
+            driving: {
+                mode: "driving",
+                origin: "稚內港",
+                destination: "紋別",
+                waypoints: ["宗谷丘陵", "猿拂", "枝幸"],
+                distanceKm: 180,
+                duration: "約 3 小時 30 分",
+                note: "08:30 首班船回稚內後取車。海岸線路程長，避免在拍照停靠中耗盡日照。",
+                mapUrl: directions("稚內港", "紋別 巨大螃蟹爪", ["猿拂村", "枝幸町"]),
+                alerts: [
+                    { label: "先確認首班船與車輛取回時間", severity: "deadline" },
+                    { label: "沿海風強，長時間駕駛要安排休息", severity: "safety" },
+                ],
+            },
+            events: [
+                {
+                    id: "d4-hime",
+                    time: "清晨",
+                    title: "姬沼湖畔導覽健行",
+                    type: "activity",
+                    priority: "optional",
+                    status: "to-confirm",
+                    description: "僅在不影響首班船報到時安排。",
+                },
+                {
+                    id: "d4-ferry",
+                    time: "08:30 目標",
+                    title: "首班船返回稚內",
+                    type: "ferry",
+                    priority: "required",
+                    status: "to-confirm",
+                    warning: "船班仍需以 Heartland Ferry 最新時刻為準。",
+                    warningSeverity: "deadline",
+                },
+                {
+                    id: "d4-crab",
+                    time: "傍晚前",
+                    title: "紋別巨大螃蟹爪",
+                    type: "activity",
+                    priority: "recommended",
+                    status: "informational",
+                    links: [{ label: "開啟地圖", url: map("紋別 巨大螃蟹爪"), kind: "map" }],
+                },
+                {
+                    id: "d4-hotel",
+                    time: "晚上",
+                    title: "紋別住宿",
+                    type: "lodging",
+                    priority: "required",
+                    status: "confirmed",
+                    lodging: {
+                        name: "NEW HUMBER",
+                        secondaryName: "ニューハンバー",
+                        meals: "不含早餐",
+                        platform: "Agoda",
+                        payment: "已付款",
+                    },
+                    links: [{ label: "開啟地圖", url: map("NEW HUMBER 紋別"), kind: "map" }],
+                },
+            ],
+        },
+        {
+            id: "day-5",
+            date: "2026-08-09",
+            dayLabel: "D5",
+            weekday: "週日",
+            region: "鄂霍次克 → 知床",
+            destination: "紋別 → 網走 → 宇登呂",
+            theme: "監獄歷史與知床夕陽，開始進入野生動物路段",
+            driving: {
+                mode: "driving",
+                origin: "紋別",
+                destination: "宇登呂",
+                waypoints: ["網走監獄"],
+                distanceKm: 160,
+                duration: "約 3 小時",
+                note: "網走停留後前往知床。越接近傍晚，越要主動降低車速。",
+                mapUrl: directions("紋別", "Shiretoko Daiichi Hotel", ["博物館 網走監獄"]),
+                alerts: [
+                    { label: "網走監獄最後入館 17:00", severity: "deadline" },
+                    { label: "傍晚留意蝦夷鹿與北狐，建議維持 50–60 km/h", severity: "safety" },
+                ],
+            },
+            events: [
+                {
+                    id: "d5-prison",
+                    time: "17:00 前入館",
+                    title: "博物館 網走監獄",
+                    type: "activity",
+                    priority: "recommended",
+                    status: "informational",
+                    warning: "最後入館時間以官方公告為準，延誤時縮短停留。",
+                    warningSeverity: "deadline",
+                    links: [
+                        { label: "開啟地圖", url: map("博物館 網走監獄"), kind: "map" },
+                        {
+                            label: "官方網站",
+                            url: "https://www.kangoku.jp/",
+                            kind: "official",
+                        },
+                    ],
+                },
+                {
+                    id: "d5-sunset",
+                    time: "傍晚",
+                    title: "宇登呂夕陽",
+                    type: "activity",
+                    priority: "optional",
+                    status: "informational",
+                    description: "只在能於天黑前安全抵達時保留。",
+                },
+                {
+                    id: "d5-safety",
+                    time: "傍晚駕駛",
+                    title: "鹿群可能突然穿越道路",
+                    type: "safety",
+                    priority: "required",
+                    status: "informational",
+                    warning: "維持 50–60 km/h，注意路肩反光，不為夕陽趕路。",
+                    warningSeverity: "safety",
+                },
+                {
+                    id: "d5-hotel",
+                    time: "晚上",
+                    title: "知床連住第一晚",
+                    type: "lodging",
+                    priority: "required",
+                    status: "confirmed",
+                    lodging: {
+                        name: "知床第一ホテル",
+                        secondaryName: "Shiretoko Daiichi Hotel",
+                        nights: 2,
+                        meals: "含早餐",
+                        platform: "Agoda",
+                    },
+                    links: [{ label: "開啟地圖", url: map("Shiretoko Daiichi Hotel"), kind: "map" }],
+                },
+            ],
+        },
+        {
+            id: "day-6",
+            date: "2026-08-10",
+            dayLabel: "D6",
+            weekday: "週一",
+            region: "知床",
+            destination: "知床五湖 → 宇登呂",
+            theme: "把車程縮短，完整留給世界自然遺產",
+            driving: {
+                mode: "driving",
+                origin: "宇登呂",
+                destination: "宇登呂",
+                waypoints: ["知床五湖", "知床觀光船"],
+                distanceKm: 50,
+                duration: "依活動安排",
+                note: "今天不追求里程；所有活動依預約、天候與接駁規則排序。",
+                mapUrl: directions("Shiretoko Daiichi Hotel", "Shiretoko Daiichi Hotel", [
+                    "知床五湖",
+                    "ウトロ港",
+                ]),
+                alerts: [
+                    { label: "五湖講習與觀光船需提前預約", severity: "deadline" },
+                    { label: "往神威卡瀑布需搭接駁，末班約 16:00", severity: "deadline" },
+                ],
+            },
+            events: [
+                {
+                    id: "d6-lakes",
+                    time: "預約時段",
+                    title: "知床五湖",
+                    type: "activity",
+                    priority: "required",
+                    status: "to-confirm",
+                    warning: "8 月需依規定參加講習或導覽，不能把現場入場視為保證。",
+                    warningSeverity: "deadline",
+                    links: [
+                        { label: "開啟地圖", url: map("知床五湖"), kind: "map" },
+                        {
+                            label: "官方資訊",
+                            url: "https://www.goko.go.jp/",
+                            kind: "official",
+                        },
+                    ],
+                },
+                {
+                    id: "d6-cruise",
+                    time: "船班待確認",
+                    title: "知床觀光船",
+                    type: "ferry",
+                    priority: "recommended",
+                    status: "to-confirm",
+                    description: "依海況與預約結果決定航線；賞鯨團列為替代選項。",
+                },
+                {
+                    id: "d6-falls",
+                    time: "16:00 前",
+                    title: "神威卡瀑布接駁",
+                    type: "transit",
+                    priority: "optional",
+                    status: "to-confirm",
+                    warning: "8 月道路管制與接駁規則需重新確認，不可直接假設能開車進入。",
+                    warningSeverity: "deadline",
+                },
+                {
+                    id: "d6-hotel",
+                    time: "晚上",
+                    title: "知床連住第二晚",
+                    type: "lodging",
+                    priority: "required",
+                    status: "confirmed",
+                    lodging: {
+                        name: "知床第一ホテル",
+                        secondaryName: "Shiretoko Daiichi Hotel",
+                        meals: "含早餐",
+                        platform: "Agoda",
+                    },
+                },
+            ],
+        },
+        {
+            id: "day-7",
+            date: "2026-08-11",
+            dayLabel: "D7",
+            weekday: "週二",
+            region: "道東三湖",
+            destination: "知床 → 摩周湖 → 阿寒湖",
+            theme: "離開海岸，進入霧、湖泊與愛努文化",
+            driving: {
+                mode: "driving",
+                origin: "知床",
+                destination: "阿寒湖",
+                waypoints: ["摩周湖第一展望台"],
+                distanceKm: 150,
+                duration: "約 3 小時",
+                note: "摩周湖常起霧，盡量中午前抵達。傍晚進阿寒湖仍需留意動物。",
+                mapUrl: directions("Shiretoko Daiichi Hotel", "Akan Yuku no Sato Tsuruga", [
+                    "摩周湖第一展望台",
+                ]),
+                alerts: [
+                    { label: "摩周湖越早到，看到湖面的機率通常越高", severity: "notice" },
+                    { label: "道東傍晚持續留意鹿群與路肩", severity: "safety" },
+                ],
+            },
+            events: [
+                {
+                    id: "d7-mashu",
+                    time: "中午前目標",
+                    title: "摩周湖第一展望台",
+                    type: "activity",
+                    priority: "required",
+                    status: "informational",
+                    description: "天氣好時湖水顏色清楚，也可留意展望台限定商品。",
+                    links: [{ label: "開啟地圖", url: map("摩周湖第一展望台"), kind: "map" }],
+                },
+                {
+                    id: "d7-ainu",
+                    time: "晚上",
+                    title: "阿寒湖愛努村",
+                    type: "activity",
+                    priority: "recommended",
+                    status: "informational",
+                    links: [{ label: "開啟地圖", url: map("阿寒湖愛努村"), kind: "map" }],
+                },
+                {
+                    id: "d7-hotel",
+                    time: "晚上",
+                    title: "阿寒湖溫泉住宿",
+                    type: "lodging",
+                    priority: "required",
+                    status: "confirmed",
+                    lodging: {
+                        name: "阿寒遊久之里鶴雅",
+                        secondaryName: "Akan Yuku no Sato Tsuruga",
+                        meals: "含早晚餐",
+                        platform: "Booking",
+                        payment: "已付款",
+                    },
+                    links: [{ label: "開啟地圖", url: map("Akan Yuku no Sato Tsuruga"), kind: "map" }],
+                },
+            ],
+        },
+        {
+            id: "day-8",
+            date: "2026-08-12",
+            dayLabel: "D8",
+            weekday: "週三",
+            region: "道東 → 美瑛",
+            destination: "阿寒湖 → 帶廣 → 青池 → 美瑛",
+            theme: "全程最長移動日，追著下午四點前的藍色",
+            driving: {
+                mode: "driving",
+                origin: "阿寒湖",
+                destination: "美瑛",
+                waypoints: ["帶廣", "白金青池", "白鬚瀑布"],
+                distanceKm: 220,
+                duration: "約 4 小時 30 分",
+                note: "盆節交通開始增加。帶廣只做有效率的午餐與休息，目標 16:00 前抵達青池。",
+                mapUrl: directions("Akan Yuku no Sato Tsuruga", "coro coro Biei", [
+                    "六花亭 帶廣本店",
+                    "白金青池",
+                    "白鬚瀑布",
+                ]),
+                alerts: [
+                    { label: "全程最長 220 km，固定安排帶廣休息", severity: "safety" },
+                    { label: "青池 16:00 前抵達，之後光線與池色會變暗", severity: "deadline" },
+                    { label: "盆節車潮開始，停車與道路都要增加緩衝", severity: "notice" },
+                ],
+            },
+            events: [
+                {
+                    id: "d8-obihiro",
+                    time: "中午",
+                    title: "帶廣休息與午餐",
+                    type: "food",
+                    priority: "recommended",
+                    status: "informational",
+                    description: "豚丼、六花亭甜點或十勝牛奶擇一，避免停留過久。",
+                    links: [{ label: "開啟地圖", url: map("六花亭 帶廣本店"), kind: "map" }],
+                },
+                {
+                    id: "d8-blue",
+                    time: "16:00 前",
+                    title: "白金青池",
+                    type: "activity",
+                    priority: "required",
+                    status: "informational",
+                    warning: "雖然可晚到，但下午四點後池水顏色會明顯變暗。",
+                    warningSeverity: "deadline",
+                    links: [{ label: "開啟地圖", url: map("白金青池"), kind: "map" }],
+                },
+                {
+                    id: "d8-falls",
+                    time: "青池後",
+                    title: "白鬚瀑布",
+                    type: "activity",
+                    priority: "recommended",
+                    status: "informational",
+                    links: [{ label: "開啟地圖", url: map("白鬚瀑布"), kind: "map" }],
+                },
+                {
+                    id: "d8-hotel",
+                    time: "晚上",
+                    title: "美瑛連住第一晚",
+                    type: "lodging",
+                    priority: "required",
+                    status: "confirmed",
+                    lodging: {
+                        name: "coro coro",
+                        nights: 2,
+                        meals: "含早餐",
+                        platform: "Booking",
+                        payment: "未付款",
+                    },
+                    links: [{ label: "開啟地圖", url: map("coro coro Biei"), kind: "map" }],
+                },
+            ],
+        },
+        {
+            id: "day-9",
+            date: "2026-08-13",
+            dayLabel: "D9",
+            weekday: "週四",
+            region: "富良野・美瑛",
+            destination: "富田農場 → 四季彩之丘 → 美瑛",
+            theme: "早起換來花田，避開盆節最密集的人潮",
+            driving: {
+                mode: "driving",
+                origin: "美瑛",
+                destination: "美瑛",
+                waypoints: ["富田農場", "四季彩之丘"],
+                distanceKm: 60,
+                duration: "約 1 小時 30 分",
+                note: "今天里程短，但停車排隊可能比開車更久。07:00 前後抵達富田農場。",
+                mapUrl: directions("coro coro Biei", "coro coro Biei", [
+                    "富田農場",
+                    "四季彩之丘",
+                ]),
+                alerts: [
+                    { label: "06:30 起床，07:00 左右抵達富田農場", severity: "deadline" },
+                    { label: "盆節高峰，晚到可能多花 2 小時排隊停車", severity: "notice" },
+                ],
+            },
+            events: [
+                {
+                    id: "d9-tomita",
+                    time: "07:00 目標",
+                    title: "富田農場",
+                    type: "activity",
+                    priority: "required",
+                    status: "informational",
+                    description: "預留約 2 小時拍照與散步；早到比增加景點更重要。",
+                    warning: "盆節期間晚到的主要成本是停車排隊。",
+                    warningSeverity: "deadline",
+                    links: [
+                        { label: "開啟地圖", url: map("富田農場"), kind: "map" },
+                        {
+                            label: "參考文章",
+                            url: "https://bobbytravel.tw/farm-tomita/",
+                            kind: "official",
+                        },
+                    ],
+                },
+                {
+                    id: "d9-shikisai",
+                    time: "上午後段",
+                    title: "四季彩之丘",
+                    type: "activity",
+                    priority: "recommended",
+                    status: "informational",
+                    description: "預留約 2 小時。若只散步拍照，可不搭遊園車。",
+                    links: [
+                        { label: "開啟地圖", url: map("四季彩之丘"), kind: "map" },
+                        {
+                            label: "參考文章",
+                            url: "https://bobbytravel.tw/shikisainooka/",
+                            kind: "official",
+                        },
+                    ],
+                },
+                {
+                    id: "d9-biei",
+                    time: "下午",
+                    title: "美瑛丘陵與彈性休息",
+                    type: "activity",
+                    priority: "optional",
+                    status: "informational",
+                    description: "花田步行量大，下午不再硬塞遠距景點。",
+                },
+                {
+                    id: "d9-hotel",
+                    time: "晚上",
+                    title: "美瑛連住第二晚",
+                    type: "lodging",
+                    priority: "required",
+                    status: "confirmed",
+                    lodging: {
+                        name: "coro coro",
+                        meals: "含早餐",
+                        platform: "Booking",
+                        payment: "未付款",
+                    },
+                },
+            ],
+        },
+        {
+            id: "day-10",
+            date: "2026-08-14",
+            dayLabel: "D10",
+            weekday: "週五",
+            region: "美瑛 → 新千歲 → 札幌",
+            destination: "美瑛 → 新千歲 → 札幌",
+            theme: "準時還車，把公路旅行交回給鐵路",
+            driving: {
+                mode: "driving",
+                origin: "美瑛",
+                destination: "新千歲機場",
+                waypoints: ["還車前加油"],
+                distanceKm: 158,
+                duration: "純車程約 2 小時 30 分",
+                note: "09:00 前後出發。車程之外必須保留盆節塞車、加油、驗車與接駁時間。",
+                mapUrl: directions("美瑛", "新千歲機場 租車還車"),
+                alerts: [
+                    { label: "13:30 前完成還車", severity: "deadline" },
+                    { label: "不要把 2.5 小時純車程當作完整所需時間", severity: "safety" },
+                ],
+            },
+            events: [
+                {
+                    id: "d10-depart",
+                    time: "09:00",
+                    title: "美瑛出發",
+                    type: "drive",
+                    priority: "required",
+                    status: "informational",
+                    warning: "盆節期間可能塞車，不安排出發前景點。",
+                    warningSeverity: "deadline",
+                },
+                {
+                    id: "d10-fuel",
+                    time: "還車前",
+                    title: "加滿油並保留收據",
+                    type: "task",
+                    priority: "required",
+                    status: "informational",
+                },
+                {
+                    id: "d10-return",
+                    time: "13:30 前",
+                    title: "新千歲機場還車",
+                    type: "task",
+                    priority: "required",
+                    status: "confirmed",
+                    warning: "截止時間包含驗車與交接，不是抵達附近的時間。",
+                    warningSeverity: "deadline",
+                },
+                {
+                    id: "d10-otaru",
+                    time: "下午",
+                    title: "小樽半日遊",
+                    type: "transit",
+                    priority: "recommended",
+                    status: "informational",
+                    description: "還車後改搭公共交通；若還車延誤，縮短或取消小樽。",
+                    links: [{ label: "開啟地圖", url: map("小樽運河"), kind: "map" }],
+                },
+                {
+                    id: "d10-hotel",
+                    time: "晚上",
+                    title: "札幌連住第一晚",
+                    type: "lodging",
+                    priority: "required",
+                    status: "confirmed",
+                    lodging: {
+                        name: "hotel androoms Sapporo Susukino",
+                        nights: 2,
+                        meals: "含早餐",
+                        platform: "Booking",
+                        payment: "已付款",
+                    },
+                    links: [
+                        {
+                            label: "開啟地圖",
+                            url: map("hotel androoms Sapporo Susukino"),
+                            kind: "map",
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            id: "day-11",
+            date: "2026-08-15",
+            dayLabel: "D11",
+            weekday: "週六",
+            region: "札幌",
+            destination: "札幌市區",
+            theme: "不再開車，用一整天慢慢收尾",
+            driving: {
+                mode: "returned",
+                origin: "札幌",
+                destination: "札幌",
+                waypoints: ["藻岩山"],
+                distanceKm: 0,
+                note: "租車已歸還。市區以步行、地下鐵與路面電車移動。",
+                alerts: [
+                    { label: "盆節週末人潮多，夜景交通預留排隊時間", severity: "notice" },
+                ],
+            },
+            events: [
+                {
+                    id: "d11-city",
+                    time: "白天",
+                    title: "札幌市區自由活動",
+                    type: "activity",
+                    priority: "recommended",
+                    status: "informational",
+                    description: "依體力安排市場、商店街或咖啡店，不再追長距離景點。",
+                },
+                {
+                    id: "d11-moiwa",
+                    time: "傍晚至晚上",
+                    title: "藻岩山夜景",
+                    type: "activity",
+                    priority: "required",
+                    status: "to-confirm",
+                    links: [
+                        { label: "開啟地圖", url: map("藻岩山纜車"), kind: "map" },
+                        {
+                            label: "官方網站",
+                            url: "https://mt-moiwa.jp/en/",
+                            kind: "official",
+                        },
+                    ],
+                },
+                {
+                    id: "d11-hotel",
+                    time: "晚上",
+                    title: "札幌連住第二晚",
+                    type: "lodging",
+                    priority: "required",
+                    status: "confirmed",
+                    lodging: {
+                        name: "hotel androoms Sapporo Susukino",
+                        meals: "含早餐",
+                        platform: "Booking",
+                        payment: "已付款",
+                    },
+                },
+            ],
+        },
+        {
+            id: "day-12",
+            date: "2026-08-16",
+            dayLabel: "D12",
+            weekday: "週日",
+            region: "札幌 → 新千歲",
+            destination: "新千歲 → 台北",
+            theme: "提早到機場，讓旅程平穩降落",
+            driving: {
+                mode: "returned",
+                origin: "札幌",
+                destination: "新千歲機場",
+                waypoints: ["JR 快速列車"],
+                distanceKm: 0,
+                note: "租車已歸還；搭 JR 或其他公共交通前往機場。",
+                alerts: [
+                    { label: "09:30 前抵達機場", severity: "deadline" },
+                ],
+            },
+            events: [
+                {
+                    id: "d12-train",
+                    time: "08:00 前後",
+                    title: "札幌 → 新千歲機場",
+                    type: "transit",
+                    priority: "required",
+                    status: "to-confirm",
+                    description: "目標 09:30 前抵達，班次與月台於前一晚再次確認。",
+                },
+                {
+                    id: "d12-airport",
+                    time: "09:30 前",
+                    title: "抵達新千歲機場",
+                    type: "task",
+                    priority: "required",
+                    status: "informational",
+                    warning: "預留退稅、托運與安檢排隊時間。",
+                    warningSeverity: "deadline",
+                },
+                {
+                    id: "d12-flight",
+                    time: "11:30–15:00",
+                    title: "IT235 新千歲 → 台北",
+                    type: "flight",
+                    priority: "required",
+                    status: "confirmed",
+                },
+            ],
+        },
+    ],
+};

--- a/src/travel/registry.ts
+++ b/src/travel/registry.ts
@@ -19,8 +19,25 @@ export const SHIMANAMI_TRAVEL_BOOK = {
     },
 } satisfies TravelBookDefinition;
 
+export const HOKKAIDO_CAR_TRAVEL_BOOK = {
+    id: "2026-hokkaido-car",
+    path: "/2026-hokkaido-car",
+    sourceDocumentIds: [
+        "1KTb3yvRp3MPHajXC5oqxgHQb6AjHNmERxbrX0KcEHmc",
+    ],
+    title: "北海道自駕",
+    eyebrow: "2026 ROAD BOOK",
+    dateRange: "8/5–8/16",
+    destinations: "道北、道東、美瑛、札幌",
+    metadata: {
+        title: "北海道自駕 2026 | TripSplit",
+        description: "從新千歲一路前往宗谷岬、利尻、知床、阿寒湖、美瑛與札幌的十二日自駕手冊。",
+    },
+} satisfies TravelBookDefinition;
+
 export const TRAVEL_BOOKS: readonly TravelBookDefinition[] = [
     SHIMANAMI_TRAVEL_BOOK,
+    HOKKAIDO_CAR_TRAVEL_BOOK,
 ];
 
 export function resourceMatchesTravelBook(
@@ -47,5 +64,11 @@ export function getTravelBooksForResources(
 }
 
 export function isPublicTravelBookPath(pathname: string) {
-    return TRAVEL_BOOKS.some((travelBook) => travelBook.path === pathname);
+    const normalizedPath = pathname
+        .replace(/\.html$/, "")
+        .replace(/\/$/, "") || "/";
+
+    return TRAVEL_BOOKS.some(
+        (travelBook) => travelBook.path === normalizedPath,
+    );
 }


### PR DESCRIPTION
## Summary

* 新增 /2026-hokkaido-car 北海道自駕旅遊書頁面。
* 將 2026/8/5–8/16 的 12 日行程轉為結構化資料。
* 每日突出顯示駕車路線、里程、預估車程、途經點與安全提醒。
* 支援依日本時間自動跳至當日行程、滑動日期、前後日切換及回到當日。
* 新增加油、野生動物、渡輪、景點截止時間及還車期限等分級警示。
* 整合住宿、餐食、付款狀態、地圖及官方資訊連結，並避免公開敏感訂房資料。
* 新增可儲存在裝置上的行前準備清單。
* 採用北海道公路主題的專屬色彩、字體與道路中心線視覺。
* 將旅遊書加入現有 registry 與首頁旅遊書列表。
* 修正公開旅遊書在靜態匯出 .html 路徑下誤顯示登入頁的問題。
* 新增完整 PRD 文件。